### PR TITLE
Added LPICE_vs_mm10 file

### DIFF
--- a/dnase/bamintersect/LP_uninformative_regions/LPICE_vs_mm10.bed
+++ b/dnase/bamintersect/LP_uninformative_regions/LPICE_vs_mm10.bed
@@ -1,0 +1,1 @@
+LPICE_downstream	368	504	Pgk1


### PR DESCRIPTION
Contains homology coordinates between LPICE_downstream and Pgk1

Will work when the bam1 genome = LPICE.

Can just add line items to this file if different ICE assemblies have different chromosome names, as long as the bam1 genome is LPICE.

Or could add logic to code which maps the one uninformative regions file to several assembly names.

fixes#89