### PR TITLE
Create output file headers in one place

### DIFF
--- a/dnase/bamintersect/filter_tsv.sh
+++ b/dnase/bamintersect/filter_tsv.sh
@@ -167,12 +167,24 @@ while read main_chrom ; do
 done < "${TMPDIR}/bam1_chroms"
 
 
+# Initialize the counts output files with a header.
+echo -e "#chrom_bam2\tchromStart_bam2\tchromEnd_bam2\tWidth_bam2\tNearestGene_bam2\tPost-filter_Reads\tchrom_bam1\tchromStart_bam1\tchromEnd_bam1\tWidth_bam1\tSample" > ${TMPDIR}/header.txt
+
 # Output the final counts files.
 if [ -f "${TMPDIR}/short_sorted_table2.bed" ]; then
     if [ ${counts_type} = "all_reads_counts" ]; then
+        mv ${TMPDIR}/header.txt ${sampleOutdir}/${sample_name}.counts.txt
         cat ${TMPDIR}/short_sorted_table2.bed >> ${sampleOutdir}/${sample_name}.counts.txt
     else
+        mv ${TMPDIR}/header.txt ${sampleOutdir}/${sample_name}.informative.counts.txt
         cat ${TMPDIR}/short_sorted_table2.bed >> ${sampleOutdir}/${sample_name}.informative.counts.txt
+    fi
+else
+    # Make empty output files
+    if [ ${counts_type} = "all_reads_counts" ]; then
+        touch ${sampleOutdir}/${sample_name}.counts.txt
+    else
+        touch ${sampleOutdir}/${sample_name}.informative.counts.txt
     fi
 fi
 

--- a/dnase/bamintersect/merge_bamintersect.sh
+++ b/dnase/bamintersect/merge_bamintersect.sh
@@ -22,12 +22,6 @@ debug_fa() {
 
 debug_fa "Starting merge_bamintersect.sh"
 
-# Initialize the counts output files with a header.
-echo -e "#chrom_bam2\tchromStart_bam2\tchromEnd_bam2\tWidth_bam2\tNearestGene_bam2\tPost-filter_Reads\tchrom_bam1\tchromStart_bam1\tchromEnd_bam1\tWidth_bam1\tSample" > ${sampleOutdir}/${sample_name}.counts.txt
-cp ${sampleOutdir}/${sample_name}.counts.txt ${sampleOutdir}/${sample_name}.informative.counts.txt
-cp ${sampleOutdir}/${sample_name}.counts.txt ${sampleOutdir}/${sample_name}_HA.counts.txt
-
-
 # First check for the "no reads to merge" problem. Also deal with the usual pipefail issue via "true".
 dir_names=($(ls -d ${INTERMEDIATEDIR}/bamintersectPyOut/*/ 2> /dev/null || true))      ## These have a trailing /
 numElements="${#dir_names[@]}"
@@ -91,6 +85,7 @@ else
     echo -e "No HAs available, so there will be no HA analysis.\n" >> "${sampleOutdir}/${sample_name}.counts.anc_info.txt"
 
     # Create empty files.
+    touch "${sampleOutdir}/${sample_name}_HA.counts.txt"
     touch "${sampleOutdir}/${sample_name}_HA.bed"
     touch "${sampleOutdir}/${sample_name}_HA.counts.anc_info.txt"
 fi


### PR DESCRIPTION
fixes #111

Single header is created in merge_bamintersect.sh

bamintersect.py only has a subset of all the column data
which is calculated and formated after bamintersect.py is run.