### PR TITLE
Added EF-1-alpha promoter, ESR1, and Piga Regions in mm10 coordinates

### DIFF
--- a/dnase/bamintersect/LP_uninformative_regions/LP_vs_mm10.bed
+++ b/dnase/bamintersect/LP_uninformative_regions/LP_vs_mm10.bed
@@ -1,3 +1,9 @@
+chr9	78480948	78481072	EF-1-alpha promoter
+chr10	4856946	4857194	ERT2, contained by Esr1
+chr10	4997824	4998017	ERT2, contained by Esr1
+chrX	164422700	164423364	Piga
+chrX	164427929	164428065	Piga
+chrX	164428537	164428674	Piga
 LP097	60	1239	EF-1-alpha promoter
 LP097	4732	5674	ERT2, contained by Esr1
 LP131	2392	3331	ERT2, contained by Esr1


### PR DESCRIPTION
These mm10 regions are homologous with regions in LP167:
<pre>
Region                    LP Feature
========================  ===================
chr9 78480948 78481072    EF-1-alpha promoter
chr10 4856946 4857194     ERT2
chr10 4997824 4998017     ERT2
chrX 164422700 164423364  Piga
chrX 164427929 164428065  Piga
chrX 164428537 164428674  Piga
</pre>

They were added to LP_vs_mm10.bed

fixes #127 
