### PR TITLE
Add mean and max windowing function parameters (py code).

### DIFF
--- a/dnase/trackhub/MakeTrackhub.py
+++ b/dnase/trackhub/MakeTrackhub.py
@@ -355,7 +355,8 @@ for assay_type in assays:
                 autoScale='off',
                 maxHeightPixels="100:30:10",
                 short_label="Cut Counts",
-                long_label="Cut Counts")
+                long_label="Cut Counts",
+                windowingFunction="maximum")
             composite.add_view(Cuts_view)
         
         if assay_type in ["DNA", "DNA Capture"]:


### PR DESCRIPTION
Fixes #128

Also skip hg38 and mm10 assemblies when doing the mauranolab hub, which does not have any.