### PR TITLE
No assembly directories for /vol/ mauranolab/sequences/hg38 or mm10

### DIFF
--- a/dnase/trackhub/makeAssemblyTracks.bash
+++ b/dnase/trackhub/makeAssemblyTracks.bash
@@ -145,7 +145,8 @@ echo Starting calls to bedToBigBed... > make_bigBED.log
 BASE="/vol/${assmbly_type2}/sequences/"
 
 # This loop generates the ".bb" files which are found in the trackhub "<genome>/data" directories.
-# genome_array just contains hg38, mm10, rn6, and cegsvectors, or hg38, mm10, mauranolab.
+# For hub_type=CEGS genome_array just contains hg38, mm10, rn6, and cegsvectors.
+# For hub_type=MAURANOLAB genome_array just contains hg38, mm10, and mauranolab.
 for genome in "${genome_array[@]}"; do
     if [ ! -d "/vol/${assmbly_type2}/sequences/${genome}" ]; then
         echo "Skipping ${genome} assemblies"


### PR DESCRIPTION
Previous discussion:

Matt:
What are the changes to makeAssemblyTracks.bash? They don't look related to #128

John:
Commit ae61c1e, which we did on Dec 13, took away the section of the code that handled the absence of hg38, mm10, rn6 in /vol/ [mauranolab, cegs] /sequences
That's OK for cegs, but they don't exist in mauranolab, which I forgot. I added a fix here.

Matt:
Best to break unrelated issues into separate commits
Why do you need to hardcode this? And how come hg38/mm10 are there but not rn6?
Please copy this discussion to a separate PR

New Discussion:
Commit ae61c1e deleted the code which looked for assembly directories, and replaced it with the list of main genomes.
For cegs this list is hg38, mm10, rn6, and cegsvectors. Assembly directories currently exist in all these, so no checks are needed.
For mauranolab this list is hg38, mm10, and maurnaolab.  So I only have to check for the absence of hg38 and mm10, which both do not exist at this time.