### PR TITLE
Add a new column to the counts_table output, showing the bam2 groupings

### DIFF
--- a/dnase/bamintersect/counts_table.sh
+++ b/dnase/bamintersect/counts_table.sh
@@ -143,6 +143,7 @@ if [ "${n}" -le "1" ]; then
     echo "[counts_table] There are no counts table reads to subset into groups."
     echo "[counts_table] Done"
     date
+    exit 0
 fi
 
 # Just in case...


### PR DESCRIPTION
I made this as a stand alone section in the current code, generating a new, wider "counts2" table.

There are other things that could be done. For example, we probably don't need the bam2
chromosome and position columns now.

But for now I think this is helpful and working correctly.