### PR TITLE
Extending genotypeClones to be used as library 

### DIFF
--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -322,7 +322,6 @@ def writeOutputFiles(G, output, outputlong, outputwide, printGraph=None):
 
 ## Given a set of nodes, it expands their neighborhood to up a certain degree of distance, which allows exploring specific node proximities
 def expandNeighborhood(G, seednodes, degree = 1, to_skip = set()):
-    union = lambda x, y: x.union(y)
     #Initialize neighborhood with seed nodes
     neighborhood = set(seednodes)
     to_skip = set(to_skip)
@@ -333,11 +332,10 @@ def expandNeighborhood(G, seednodes, degree = 1, to_skip = set()):
     return neighborhood
 
 ## Assign assigns values to nodes based on a dictionary of node -> value, it can be used to assign nodes transfections for example
-def assignToNodes(G, key, values):
-    for n in values:
-        if not G.has_node(n):
-            continue
-        G.nodes[n][key] = values[n]
+def assignToNodes(G, key, annotationdict, default=None):
+    for n in G.nodes:
+        val = annotationdict.get(n, default)
+        G.nodes[n][key] = val
 
 ## Convert bipartite graph into a Jaccard index graph of the cells
 def toJaccard(G):


### PR DESCRIPTION
This PR aims to update and extend `genotypeClones.py` that allows it to be used as a library as well as an analysis script. For such purpose, functions dependencies to global variables were clear and the main script process was moved into `__name__ == "__main__"` to be executed only when running it as a script.

Furthermore:
- Two new functions were added:
    - **expandNeighborhood**: that given a set of nodes, it expands their neighborhood to up a certain degree of distance, which allows exploring specific node proximities.
    - **assignToNodes**: that assigns values to nodes based on a dictionary of `node -> value`, it can be used to assign nodes transfections for example
- and **printGraph** was extended to allow more malleability of the plotting options


### Usage example

```
import sys
import random

random.seed(20200122)

## e.g. link to my local clone
sys.path.append("/vol/mauranolab/ribeia01/src/mapping/transposon")
import genotypeClones as gc

G = gc.initializeGraphFromInput("/vol/mauranolab/ribeia01/sc_rnaseq/BS03735A-20191218_T0213A_T0215A_T0216B_T0217B_Pool1_10xRNA.barcode.counts.byCell.txt", 2)
gc.pruneEdgesLowPropOfReads(G, 0.15, type="BC")
gc.pruneEdgesLowPropOfReads(G, 0.01, type="cell")

nodes = list(G.nodes)
random.shuffle(nodes)
neighbors = gc.expandNeighborhood(G, [nodes[0]], degree = 4)

gc.printGraph(G.subgraph(neighbors),
    node_color_dict=dict(BC='gray', cell='steelblue'))
```