### PR TITLE
save the list of BCs with 2+ insertions in analyzeIntegrations.sh

### DIFF
--- a/transposon/analyzeIntegrations.sh
+++ b/transposon/analyzeIntegrations.sh
@@ -245,7 +245,7 @@ awk -v cutoff=2 '{if($0>=cutoff) {print cutoff "+"} else {print}}' | sort -g | u
 cat $TMPDIR/${sample}.barcodes.coords.minReadCutoff.bed | awk -F "\t" 'BEGIN {OFS="\t"} {print $4}' | sort | uniq -c | sort -nk1 | awk '$1==1 {print $2}' > $TMPDIR/${sample}.singleIns.txt
 
 # save BC list of insertions with more than one location
-cat $TMPDIR/${sample}.barcodes.coords.minReadCutoff.bed | awk -F "\t" 'BEGIN {OFS="\t"} {print $4}' | sort | uniq -c | sort -nk1 | awk '$1>1 {print $2}' > $OUTDIR/${sample}.MultIns.txt
+cat $TMPDIR/${sample}.barcodes.coords.minReadCutoff.bed | awk -F "\t" 'BEGIN {OFS="\t"} {print $4}' | sort | uniq -c | sort -nk1 | awk '$1>1 {print $2}' > $OUTDIR/${sample}.multiIns.txt
 
 #Identify insertion sites with more than one BC
 cat $TMPDIR/${sample}.barcodes.coords.minReadCutoff.bed | awk -F "\t" 'BEGIN {OFS="\t"} {$4="."; $5=0; print}' | uniq -c | awk 'BEGIN {OFS="\t"} $1==1 {print $2, $3, $4, $5, $6, $7}' | sort-bed - > $TMPDIR/${sample}.singleBC.bed


### PR DESCRIPTION
I've added a single command to `analyzeIntegrations.sh` to save a list of BCs with 2+ insertion sites in order to guarantee consistency in further analysis.