### PR TITLE
fix analyzeIntegrations.sh for aggregated analysis

### DIFF
--- a/transposon/analyzeIntegrations.sh
+++ b/transposon/analyzeIntegrations.sh
@@ -40,11 +40,8 @@ if [ ! -s "$OUTDIR/${sample}.bam" ]; then
     exit 2
 fi
 
-if [ "$(samtools view -h $OUTDIR/${sample}.bam | head -n 1000 | samtools view -f1 -c -)" -gt 0 ]; then
-    samflags="-f 128 -F 512"
-else
-    samflags="-F 512"
-fi
+## Ignore R1 in paired without excluding single-end reads
+samflags="-F 64 -F 512"
 
 echo "Analyzing data for ${sample}"
 echo "Analyzing read mapping (minReadCutoff=${minReadCutoff})"


### PR DESCRIPTION
Fix to enable the analysis of aggregated iPCR data with both single-end and paired-end mapping.

This fix consists of changing `analyzeIntegrations.sh` `samflags` to exclude R1 reads instead of selecting R2. This allows us to process only R2 mapping in paired-end mapping without excluding single-end data.