### PR TITLE
Track hub deployment

### DIFF
--- a/dnase/trackhub/deployment_scripts/make_dev_hub.bash
+++ b/dnase/trackhub/deployment_scripts/make_dev_hub.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#####################################################################
+# Clean out old hub:
+
+rm -rf /vol/cegs/public_html/trackhub_dev/hg38
+rm -rf /vol/cegs/public_html/trackhub_dev/mm10
+rm -rf /vol/cegs/public_html/trackhub_dev/rn6
+rm -rf /vol/cegs/public_html/trackhub_dev/cegsvectors
+
+rm -f  /vol/cegs/public_html/trackhub_dev/genomes.txt
+rm -f  /vol/cegs/public_html/trackhub_dev/description.html
+rm -f  /vol/cegs/public_html/trackhub_dev/hub.txt
+rm -f  /vol/cegs/public_html/trackhub_dev/README
+
+rm -f  /vol/cegs/public_html/trackhub_dev/publicdata
+rm -f  /vol/cegs/public_html/trackhub_dev/aggregations
+rm -f  /vol/cegs/public_html/trackhub_dev/mapped
+
+#####################################################################
+
+src_dev/update_tracks.bash CEGS /vol/cegs/public_html/trackhub_dev "CEGS Dev" "CEGS Development Hub" \
+                                https://cegs:bigdna@cascade.isg.med.nyu.edu/cegs
+
+# Hub address will be:  https://cegs:bigdna@cascade.isg.med.nyu.edu/cegs/trackhub_dev/hub.txt
+

--- a/dnase/trackhub/deployment_scripts/make_maurano_hub.bash
+++ b/dnase/trackhub/deployment_scripts/make_maurano_hub.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+rm -rf /home/cadlej01/public_html/trackhub
+mkdir /home/cadlej01/public_html/trackhub
+
+# src_prod/update_tracks.bash MAURANOLAB /home/cadlej01/public_html/trackhub "Maurano Lab" "Maurano Lab Hub" \
+#                       https://mauranolab:chromatin@cascade.isg.med.nyu.edu/~cadlej01
+
+src_dev/update_tracks.bash MAURANOLAB /home/cadlej01/public_html/trackhub "Maurano Lab" "Maurano Lab Hub" \
+                      https://mauranolab:chromatin@cascade.isg.med.nyu.edu/~cadlej01
+
+# Hub address will be:  https://mauranolab:chromatin@cascade.isg.med.nyu.edu/~cadlej01/trackhub/hub.txt
+

--- a/dnase/trackhub/deployment_scripts/make_prod_hub.bash
+++ b/dnase/trackhub/deployment_scripts/make_prod_hub.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#####################################################################
+# Clean out old hub:
+
+rm -rf /vol/cegs/public_html/trackhub/hg38
+rm -rf /vol/cegs/public_html/trackhub/mm10
+rm -rf /vol/cegs/public_html/trackhub/rn6
+rm -rf /vol/cegs/public_html/trackhub/cegsvectors
+
+rm -f  /vol/cegs/public_html/trackhub/genomes.txt
+rm -f  /vol/cegs/public_html/trackhub/description.html
+rm -f  /vol/cegs/public_html/trackhub/hub.txt
+rm -f  /vol/cegs/public_html/trackhub/README
+
+rm -f  /vol/cegs/public_html/trackhub/publicdata
+rm -f  /vol/cegs/public_html/trackhub/aggregations
+rm -f  /vol/cegs/public_html/trackhub/mapped
+
+#####################################################################
+
+src_prod/update_tracks.bash CEGS /vol/cegs/public_html/trackhub "CEGS" "CEGS Hub" \
+                                 https://cegs:bigdna@cascade.isg.med.nyu.edu/cegs
+
+# Hub address will be:  https://cegs:bigdna@cascade.isg.med.nyu.edu/cegs/trackhub/hub.txt
+

--- a/dnase/trackhub/deployment_scripts/make_sars_hub.bash
+++ b/dnase/trackhub/deployment_scripts/make_sars_hub.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#####################################################################
+# Clean out old hub:
+
+rm -rf /home/cadlej01/public_html/trackhub_sars
+mkdir /home/cadlej01/public_html/trackhub_sars
+
+#####################################################################
+
+src_dev/update_tracks.bash SARS /home/cadlej01/public_html/trackhub_sars "SARS" "SARS Hub" \
+                      https://mauranolab:chromatin@cascade.isg.med.nyu.edu/~cadlej01
+
+# Hub address will be:  https://mauranolab:chromatin@cascade.isg.med.nyu.edu/~cadlej01/trackhub_sars/hub.txt
+


### PR DESCRIPTION
Added a deployment_script directory which contains the scripts I run to update the hubs.

They normally exist in /vol/cegs/src/trackhub

The comments about deployment in update_tracks.bash are very old, and are no longer valid.
I'll update them after you take a look at these scripts.

My current deployment practice for prod is to run the prod code into the dev hub first.
Then if all is well, I run it into the prod hub.

fixes #170