### PR TITLE
Change hub deployment method

### DIFF
--- a/dnase/trackhub/update_tracks.bash
+++ b/dnase/trackhub/update_tracks.bash
@@ -104,7 +104,6 @@ echo TMPDIR is: ${TMPDIR}
 ############################################################################
 
 hub_target="/${TMPDIR}/trackhub"
-rm -rf ${hub_target}
 mkdir ${hub_target}
 
 # Make soft links in hub directory, so we can have multiple hubs with their own data sources in public_html.


### PR DESCRIPTION
Now building the hub in a tmp directory, hubchecking it there, and only then
deleting the old hub and replacing it with the new. Also, since we are now
using relative paths in our track definitions, we no longer need to pass the
hub's URL (and associated login/password) to update_tracks.bash

The usage comments in update_tracks.bash have also been updated to reflect the changes.