### PR TITLE
Fix no unscaffolded chrom bug on analyzeIntegrations.sh

### DIFF
--- a/transposon/analyzeIntegrations.sh
+++ b/transposon/analyzeIntegrations.sh
@@ -66,7 +66,6 @@ echo -n -e "${sample}\tTotal unmapped reads\t"
 samtools view -f 516 -c $OUTDIR/${sample}.bam
 
 echo -n -e "${sample}\tTotal reads mapped to unscaffolded contigs\t"
-#BUGBUG nonzero exit if those chroms are not present
 samtools view -f 512 $OUTDIR/${sample}.bam | cut -f3 | awk '$0 ~ /hap|random|^chrUn_|_alt$|scaffold|^C\d+/' | wc -l
 
 echo


### PR DESCRIPTION
This is a fix to the nonzero exit bug when no unscaffolded contig is present during `analyzeIntegrations.sh` analysis.

I replace `grep` with  `awk` to avoid the nonzero exit which terminates the script.

another option is to append `|| true` to the end of the line which would also replace the non-zero exit.