### PR TITLE
Select lines from samplesforTrackhub output via mappedgenome, not ann…

### DIFF
--- a/dnase/trackhub/make_tracks.bash
+++ b/dnase/trackhub/make_tracks.bash
@@ -37,6 +37,7 @@ Rscript --vanilla ${src}/samplesforTrackhub.R \
         --quiet
 
 # Split up the samplesforTrackhub.R output into separate files for each genome.
+# It is important that the cegsvectors assemblies do not unintentionally include standard genome names in their own names.  For example, if a Mapped_genome is cegsvectors_Myspecialmm10gene, then the track will appear in both the cegsvectors genome files and in the mm10 files.
 for i in "${genome_array[@]}"; do
     mlr --tsv filter -S "'\$Mapped_Genome =~ \".*${i}.*\"'" ${outfile} > ${outfile_base}_${i}_consolidated.tsv
 done


### PR DESCRIPTION
…otationgenonome

In make_tracks.bash, select lines from the samplesforTrackhub.R output via
the Mapped_genome column, not the Annotation_genome column.

Also, do not search for exact matches.  The lines are selected by genome, which
is normally one of hg38, rn6, mm10, etc.  Just regex the Mapped_genome contents
for the correct genome.  If two genomes appear in the field (as in hg38_full_wuhCor1),
then it is OK to have the line appear as input to both trackhub files.

It is important that the cegsvectors assemblies do not unintentionally include standard genome
names in their own names.  For example, if a Mapped_genome is cegsvectors_Myspecialmm10gene,
then the track will appear in both the cegsvectors genome files and in the mm10 files.

fixes #192