### PR TITLE
Add `Number of PE reads` to analyzeIntegrations.sh (#197)

### DIFF
--- a/transposon/analyzeIntegrations.sh
+++ b/transposon/analyzeIntegrations.sh
@@ -98,11 +98,11 @@ samtools view ${samflags} $OUTDIR/${sample}.bam | awk -F "\t" 'BEGIN {OFS="\t"} 
     print $3, chromStart, chromEnd, $1, "id-" NR, strand; \
 }' | sort-bed - > $TMPDIR/${sample}.coords.bed
 
-echo -n -e "${sample}\tNumber of PE reads mapped passing all filters\t"
-samtools view -c ${samflags} -f 1 $OUTDIR/${sample}.bam
-
 echo -e -n "${sample}\tNumber of reads passing all filters\t"
 cat $TMPDIR/${sample}.coords.bed | wc -l
+
+echo -n -e "${sample}\tNumber of pairedreads mapped passing all filters\t"
+samtools view -c ${samflags} -f 1 $OUTDIR/${sample}.bam
 
 
 zcat -f $OUTDIR/${sample}.barcodes.txt.gz | awk -F "\t" 'BEGIN {OFS="\t"} $1!=""' |


### PR DESCRIPTION
Include `Number of PE reads` to `analyzeIntegrations.sh` report.

NOTE:  that this annotation should be equal to `Number of reads passing all filters` when using only PE libraries on the analysis.

fixes #197