### PR TITLE
explicit submitMerge.sh module dependencies

### DIFF
--- a/transposon/submitMerge.sh
+++ b/transposon/submitMerge.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 #https://stackoverflow.com/questions/51256738/multiple-instances-of-python-running-simultaneously-limited-to-35
 export OPENBLAS_NUM_THREADS=1
 
+module load python/3.8.1
+module load weblogo/3.5.0
+module load ImageMagick
 module load miller
 module load pigz
 module load samtools/1.9


### PR DESCRIPTION
When I was running it locally, my execution failed due to some missing modules:
- weblogo
- ImageMagick
- Python

I've explicitly added the requirement to submitMerge.sh