### PR TITLE
Avoids a set -u error when range vector is empty, and for loop can be…

### DIFF
--- a/dnase/trackhub/makeDescFiles.bash
+++ b/dnase/trackhub/makeDescFiles.bash
@@ -110,8 +110,7 @@ find_readcounts () {
             echo "[makeDescFiles.bash] WARNING No subdirectories with a readcounts file in ${dir_base}${flowcell}"
             # But print the data directory path:
             
-            subdir_names=(`find ${flowcelldir} -mindepth 1 -maxdepth 1 -type d`)
-            for j in "${subdir_names[@]}"; do
+            for j in `find ${flowcelldir} -mindepth 1 -maxdepth 1 -type d`; do
                 BASEwoSlash=${j%/}        # Strip trailing slash
                 BASE=${BASEwoSlash##*/}   # Get subdir name
                 


### PR DESCRIPTION
… skipped.