### PR TITLE
Only group reads with same orientation

### DIFF
--- a/dnase/bamintersect/counts_table.sh
+++ b/dnase/bamintersect/counts_table.sh
@@ -115,59 +115,60 @@ merge_tight() {
 }
 
 bamintersectBED12_byStrand="${TMPDIR}/${sample_name}.bamintersectBED12_byStrand.bed"
-for strand in "+" "-"; do
-    # Get reads from just one strand.
-    awk -v strand=${strand} 'BEGIN {FS="\t";OFS="\t"} ($6==strand)' ${bamintersectBED12} > ${bamintersectBED12_byStrand}
-    if [ ! -s ${bamintersectBED12_byStrand} ]; then
-        # No reads for this strand are present. Create an empty output file for mlr.
-        touch ${OUTBASE}.counts.${strand}.txt
-        continue
-    fi
-    
-    #Generate bam1 regions
-    merge_tight ${bamintersectBED12_byStrand} 500 > ${TMPDIR}/${sample_name}.regions.bam1.bed
-    
-    #Split output into separate files by bam1 region
-    mkdir $TMPDIR/bam2readsByBam1region
-    bedmap --bp-ovr 1 --delim "|" --multidelim "|" --echo --echo-map ${TMPDIR}/${sample_name}.regions.bam1.bed ${bamintersectBED12_byStrand} |
-    #Output format: bam2 chrom chromStart, chromEnd, bam1region
-    awk -v outdir=$TMPDIR/bam2readsByBam1region -F "|" 'BEGIN {OFS="\t"} {split($1, bam1region, "\t"); for(i=2; i<=NF; i++) {split($i, bam2read, "\t"); print bam2read[7], bam2read[8], bam2read[9], bam1region[4] > outdir "/" NR ".unsorted.bam2.bed"}}'
-    
-    for file in $TMPDIR/bam2readsByBam1region/*.unsorted.bam2.bed; do
-        cur=`basename ${file} .unsorted.bam2.bed`
-        cat ${file} | sort-bed - > $TMPDIR/bam2readsByBam1region/${cur}.sorted.bam2.bed
+for strand_bam1 in "+" "-"; do
+    for strand_bam2 in "+" "-"; do
+        # Get reads from just one strand.
+        awk -v strand1=${strand_bam1} -v strand2=${strand_bam2} 'BEGIN {FS="\t";OFS="\t"} {if($6==strand1 && $12==strand2){print $0}}' ${bamintersectBED12} > ${bamintersectBED12_byStrand}
+        if [ ! -s ${bamintersectBED12_byStrand} ]; then
+            # No reads for this strand combination are present.
+            continue
+        fi
         
-        #Generate bam2 regions for the set of reads from each bam1 region
-        merge_tight $TMPDIR/bam2readsByBam1region/${cur}.sorted.bam2.bed 500 | cut -f1-3 |
-        #Add a bam1 region id for each read that maps to this bam2 region
-        bedmap --delim "\t" --multidelim ";" --echo --echo-map-id - $TMPDIR/bam2readsByBam1region/${cur}.sorted.bam2.bed |
-        awk -F "\t" 'BEGIN {OFS="\t"} {split($4, bam1region, ";"); for(i=1; i<=length(bam1region); i++) {print $1, $2, $3, bam1region[i]}}'
-    done |
-    #Each line is the pair of bam1/bam2 regions spanned by a single mate pair, so now count them
-    sort -k1,1 -k2,2 -k4,4 | uniq -c |
-    #Now filter for minimum reads and finalize output columns
-    awk -v minReadsCutoff=2 'BEGIN {OFS="\t"} $1>=minReadsCutoff {split($5, bam1region, /[:-]/); print $2, $3, $4, $4-$3, $1, bam1region[1], bam1region[2], bam1region[3], bam1region[3]-bam1region[2]}' | sort-bed - |
-    #Add gene name to bam2
-    annotateNearestGeneName - ${bam2genome} |
-    #switch to bam1 coordinates, leaving the bam2 gene name at the end where it belongs
-    awk -F "\t" 'BEGIN {OFS="\t"} {print $6, $7, $8, $9, $5, $1, $2, $3, $4, $10}' | sort-bed - |
-    #Add gene name to bam1
-    annotateNearestGeneName - ${bam1genome} |
-    #Sort by Reads, chrom_bam2, chromStart_bam2
-    #tried mlr but it doesn't like the field name below
-    #mlr --tsv sort -nr Reads -f ${#chrom_bam2} -n chromStart_bam2
-    sort -k5,5nr -k1,1 -k2,2n |
-    #Reorder columns to put bam1 gene where it belongs
-    awk -v short_sample_name=`echo "${sample_name}" | cut -d "." -f1` -v strand=${strand} -F "\t" 'BEGIN {OFS="\t"; print "#chrom_bam1", "chromStart_bam1", "chromEnd_bam1", "Width_bam1", "NearestGene_bam1", "chromStrand_bam1", "Reads", "chrom_bam2", "chromStart_bam2", "chromEnd_bam2", "Width_bam2", "NearestGene_bam2", "Sample"} {print $1, $2, $3, $4, $11, strand, $5, $6, $7, $8, $9, $10, short_sample_name}' > ${OUTBASE}.counts.${strand}.txt
-    
-    #Cleanup
-    rm -rf $TMPDIR/bam2readsByBam1region
+        #Generate bam1 regions
+        merge_tight ${bamintersectBED12_byStrand} 500 > ${TMPDIR}/${sample_name}.regions.bam1.bed
+        
+        #Split output into separate files by bam1 region
+        mkdir $TMPDIR/bam2readsByBam1region
+        bedmap --bp-ovr 1 --delim "|" --multidelim "|" --echo --echo-map ${TMPDIR}/${sample_name}.regions.bam1.bed ${bamintersectBED12_byStrand} |
+        #Output format: bam2 chrom chromStart, chromEnd, bam1region
+        awk -v outdir=$TMPDIR/bam2readsByBam1region -F "|" 'BEGIN {OFS="\t"} {split($1, bam1region, "\t"); for(i=2; i<=NF; i++) {split($i, bam2read, "\t"); print bam2read[7], bam2read[8], bam2read[9], bam1region[4] > outdir "/" NR ".unsorted.bam2.bed"}}'
+        
+        for file in $TMPDIR/bam2readsByBam1region/*.unsorted.bam2.bed; do
+            cur=`basename ${file} .unsorted.bam2.bed`
+            cat ${file} | sort-bed - > $TMPDIR/bam2readsByBam1region/${cur}.sorted.bam2.bed
+            
+            #Generate bam2 regions for the set of reads from each bam1 region
+            merge_tight $TMPDIR/bam2readsByBam1region/${cur}.sorted.bam2.bed 500 | cut -f1-3 |
+            #Add a bam1 region id for each read that maps to this bam2 region
+            bedmap --delim "\t" --multidelim ";" --echo --echo-map-id - $TMPDIR/bam2readsByBam1region/${cur}.sorted.bam2.bed |
+            awk -F "\t" 'BEGIN {OFS="\t"} {split($4, bam1region, ";"); for(i=1; i<=length(bam1region); i++) {print $1, $2, $3, bam1region[i]}}'
+        done |
+        #Each line is the pair of bam1/bam2 regions spanned by a single mate pair, so now count them
+        sort -k1,1 -k2,2 -k4,4 | uniq -c |
+        #Now filter for minimum reads and finalize output columns
+        awk -v minReadsCutoff=2 'BEGIN {OFS="\t"} $1>=minReadsCutoff {split($5, bam1region, /[:-]/); print $2, $3, $4, $4-$3, $1, bam1region[1], bam1region[2], bam1region[3], bam1region[3]-bam1region[2]}' | sort-bed - |
+        #Add gene name to bam2
+        annotateNearestGeneName - ${bam2genome} |
+        #switch to bam1 coordinates, leaving the bam2 gene name at the end where it belongs
+        awk -F "\t" 'BEGIN {OFS="\t"} {print $6, $7, $8, $9, $5, $1, $2, $3, $4, $10}' | sort-bed - |
+        #Add gene name to bam1
+        annotateNearestGeneName - ${bam1genome} |
+        #Sort by Reads, chrom_bam2, chromStart_bam2
+        #tried mlr but it doesn't like the field name below
+        #mlr --tsv sort -nr Reads -f ${#chrom_bam2} -n chromStart_bam2
+        sort -k5,5nr -k1,1 -k2,2n |
+        #Reorder columns to put bam1 gene where it belongs
+        awk -v short_sample_name=`echo "${sample_name}" | cut -d "." -f1` -v strand1=${strand_bam1} -v strand2=${strand_bam2} -F "\t" 'BEGIN {OFS="\t"; print "#chrom_bam1", "chromStart_bam1", "chromEnd_bam1", "Width_bam1", "NearestGene_bam1", "Strand_bam1", "Reads", "chrom_bam2", "chromStart_bam2", "chromEnd_bam2", "Width_bam2", "NearestGene_bam2", "Strand_bam2", "Sample"} {print $1, $2, $3, $4, $11, strand1, $5, $6, $7, $8, $9, $10, strand2, short_sample_name}' >> ${OUTBASE}.counts.tmp.txt
+        
+        #Cleanup
+        rm -rf $TMPDIR/bam2readsByBam1region
+    done
 done
 
-# Merge the stranded output files.
-mlr --tsv cat ${OUTBASE}.counts.+.txt ${OUTBASE}.counts.-.txt |
+# Delete extra column header lines, and sort.
+awk 'BEGIN {FS="\t";OFS="\t"} {if(NR==1 || $1!="#chrom_bam1"){print $0}else{next}}' ${OUTBASE}.counts.tmp.txt |
 mlr --tsv sort -f \#chrom_bam1 -n chromStart_bam1 > ${OUTBASE}.counts.txt
-rm ${OUTBASE}.counts.+.txt  ${OUTBASE}.counts.-.txt
+rm ${OUTBASE}.counts.tmp.txt
 
 #####################################################################################
 


### PR DESCRIPTION
In counts_table.sh, when we make clusters of nearby reads, we require that the clustered reads all be in the same orientation. The strand will then be reported in the bamintersect output.

Fixes #212