### PR TITLE
Change bam exclude flags from 3078 to 3076

### DIFF
--- a/dnase/bamintersect/submit_bamintersect.sh
+++ b/dnase/bamintersect/submit_bamintersect.sh
@@ -69,8 +69,7 @@ Usage: $(basename "$0") [Options]
         # Require read is paired
     
     --bam1_exclude_flags {a sam format flag value for bam1 reads to be excluded from the analysis. Default = 3076}
-        # Exclude mapped in proper pair
-        # Exclude read unmapped.
+        # Exclude unmapped read.
         # Exclude PCR or optical duplicates.
         # Exclude supplementary aligments.
     

--- a/dnase/bamintersect/submit_bamintersect.sh
+++ b/dnase/bamintersect/submit_bamintersect.sh
@@ -68,7 +68,7 @@ Usage: $(basename "$0") [Options]
     --bam1_keep_flags {a sam format flag value required of all bam1 reads to be included in the analysis. Default = 1}
         # Require read is paired
     
-    --bam1_exclude_flags {a sam format flag value for bam1 reads to be excluded from the analysis. Default = 3078}
+    --bam1_exclude_flags {a sam format flag value for bam1 reads to be excluded from the analysis. Default = 3076}
         # Exclude mapped in proper pair
         # Exclude read unmapped.
         # Exclude PCR or optical duplicates.
@@ -76,7 +76,7 @@ Usage: $(basename "$0") [Options]
     
     --bam2_keep_flags {a sam format flag value required of all bam2 reads to be included in the analysis. Default = 9}
     
-    --bam2_exclude_flags {a sam format flag value for bam2 reads to be excluded from the analysis. Default = 3078}
+    --bam2_exclude_flags {a sam format flag value for bam2 reads to be excluded from the analysis. Default = 3076}
     
     --reads_match {no argument}
            # This flag tells bam_intersect.py how to match the reads from each bam file.
@@ -161,9 +161,9 @@ eval set -- "${options}"
     reads_match=""
     integrationsite="null"
     bam1_keep_flags="1"
-    bam1_exclude_flags="3078"
+    bam1_exclude_flags="3076"
     bam2_keep_flags="9"
-    bam2_exclude_flags="3078"
+    bam2_exclude_flags="3076"
     verbose=False
     max_mismatches=1
 


### PR DESCRIPTION
When bamintersect is doing the initial bam1 sort of all the mm10/hg38/rn6 reads (in sort_bamintersect.sh), it is throwing out all the proper pairs from the bam1 file.

So when the cegsvectors insertion is almost identical to the deletion, this means almost all reads with unmapped mates in the bam2 file will have no corresponding mate in the insertion chromosome in the list of surviving bam1 reads.

This commit stops the above behavior.