### PR TITLE
fix genotypeClones.py typo

### DIFF
--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -511,7 +511,7 @@ if __name__ == "__main__":
     parser.add_argument('--maxpropreads', action='store', type=int, default=0.1, help='Edges joining communities must have fewer than this number of UMIs as proportion of the smaller community they bridge')
 
     parser.add_argument("--splitConflictingClones", action="store", type=str, default=None, help="Run a post-processing clean-up and remove conflicting cells based on BCs annotation.")
-    parset.add_argument("--maxConflictRate", action="store", type=float, default=0.0, help="Maximum non-majority transfection UMI rate to remove a conflicting cells")
+    parser.add_argument("--maxConflictRate", action="store", type=float, default=0.0, help="Maximum non-majority transfection UMI rate to remove a conflicting cells")
 
     parser.add_argument('--printGraph', action='store', type=str, help='Plot a graph for each clone into this directory')
     


### PR DESCRIPTION
Hi Matt,
on my last PR I just notice a typo of `parset` instead of `parser` and I am sending this to fix it. Also, the `analyzeBCcounts.sh` is calling the script defaulting `--maxConflictRate` to 0.0 which corresponds to the harsh cutoff, do you want to use it or 0.10 instead?