### PR TITLE
New post genotypeClones.py clean-up interface proposal

### DIFF
--- a/transposon/analyzeBCcounts.sh
+++ b/transposon/analyzeBCcounts.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -eu -o pipefail
 
-src=/vol/mauranolab/mapped/src/transposon
+# src=/vol/mauranolab/mapped/src/transposon
+src=/vol/mauranolab/ribeia01/transposon_10x/mapping/transposon
 
 #TODO inconsistently applied
 minReadCutoff=$1
@@ -172,7 +173,7 @@ if [ "${minCellBCLength}" -gt 0 ]; then
         #June 2020 scaled
         scRNAseqbase="/vol/mauranolab/transposon/scrnaseq/merged_T0219toT0222"
         #/vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/blacklist_conflicting_cells.txt
-        genotypeClonesArgs="--blacklist /vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/blacklist_multisite.txt,/vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/blacklist_shared.txt --annotateclones /vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/bc_transfection-occurrence.txt.gz --splitConflictingClones transfection"
+        genotypeClonesArgs="--blacklist /vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/blacklist_multisite.txt,/vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/blacklist_shared.txt --annotateclones /vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/bc_transfection-occurrence.txt.gz"
     else
         echo "ERROR can't find the right scRNAseqbase"
         exit 1

--- a/transposon/analyzeBCcounts.sh
+++ b/transposon/analyzeBCcounts.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-# src=/vol/mauranolab/mapped/src/transposon
-src=/vol/mauranolab/ribeia01/transposon_10x/mapping/transposon
+src=/vol/mauranolab/mapped/src/transposon
 
 #TODO inconsistently applied
 minReadCutoff=$1

--- a/transposon/analyzeBCcounts.sh
+++ b/transposon/analyzeBCcounts.sh
@@ -172,7 +172,7 @@ if [ "${minCellBCLength}" -gt 0 ]; then
         #June 2020 scaled
         scRNAseqbase="/vol/mauranolab/transposon/scrnaseq/merged_T0219toT0222"
         #/vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/blacklist_conflicting_cells.txt
-        genotypeClonesArgs="--blacklist /vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/blacklist_multisite.txt,/vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/blacklist_shared.txt --annotateclones /vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/bc_transfection-occurrence.txt.gz"
+        genotypeClonesArgs="--blacklist /vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/blacklist_multisite.txt,/vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/blacklist_shared.txt --annotateclones /vol/mauranolab/ribeia01/transposon_10x/T0219toT0221/bc_transfection-occurrence.txt.gz --transfectionKey transfection --removeMinorityBCsFromConflictingCells 0.20 --removeConflictingCells"
     else
         echo "ERROR can't find the right scRNAseqbase"
         exit 1

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -558,8 +558,14 @@ if __name__ == "__main__":
     breakUpWeaklyConnectedCommunities(G, minCentrality=args.minCentrality, maxPropReads=args.maxpropreads, verbose=args.verbose, graphOutput=args.printGraph)
     
     clones = identifyClones(G)
-    if args.transfectionKey is not None and args.maxConflictRate is not None:
-        pruneConflictingEdges(G, args.transfectionKey, args.maxConflictRate)
+    if args.maxConflictRate is not None:
+        if args.transfectionKey is not None:
+            print("[genotypeClones] WARNING `--transfectionKey` is required to clean conflicting edges", file=sys.stderr)
+        else:
+            pruneConflictingEdges(G, args.transfectionKey, args.maxConflictRate)
     if args.transfectionKey is not None and args.removeConflictingCells:
-        pruneConflictingCells(G, args.transfectionKey, args.maxConflictRate)
+        if args.transfectionKey is not None:
+            print("[genotypeClones] WARNING `--transfectionKey` is required to remove conflicting cells", file=sys.stderr)
+        else:
+            pruneConflictingCells(G, args.transfectionKey, args.maxConflictRate)
     writeOutputFiles(G, clones, args.output, args.outputlong, args.outputwide, args.cloneobj, args.printGraph)

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -178,7 +178,7 @@ def pruneEdgesLowPropOfReads(G, minPropOfBCReads, minPropOfCellReads):
     print("[genotypeClones] pruneEdgesLowPropOfReads - Removed ", len(edgesToRemove), " total edges", sep="", file=sys.stderr)
     pruneOrphanNodes(G)
 
-
+# Computes and return UMI proportion of a [key] attribute value among a set of [nodes]
 def computeKeyRate(G, nodes, key):
     total = 0
     rate = dict()

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -200,9 +200,9 @@ def pruneConflictingEdges(G, transfectionKey, maxConflict):
     for cell in [x for x in G.nodes if G.nodes[x]['type'] == "cell"]:
         bcs = [x for (_, x) in G.edges(cell) if G.nodes[x][transfectionKey] not in skip]
         transfection_rate = computeKeyRate(G, bcs, transfectionKey)
-        transfection_majority = max(transfection_rate, key = transfection_rate.get)
         ## Skip cells with BCs from single transfection or no transfection and those with too high conflict rate
         if len(transfection_rate) > 1 and (1 - transfection_rate[transfection_majority]) <= maxConflict:
+            transfection_majority = max(transfection_rate, key = transfection_rate.get)
             keep = [transfection_majority] + skip
             edges_to_remove.update([(cell, x) for x in bcs if G.nodes[x][transfectionKey] not in keep])
     remove_edges(G, edges_to_remove)

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -178,7 +178,7 @@ def pruneEdgesLowPropOfReads(G, minPropOfBCReads, minPropOfCellReads):
     print("[genotypeClones] pruneEdgesLowPropOfReads - Removed ", len(edgesToRemove), " total edges", sep="", file=sys.stderr)
     pruneOrphanNodes(G)
 
-# Computes and return UMI proportion of a [key] attribute value among a set of [nodes]
+# Computes and return a dictionary of the [key] attribute value UMI proportion among a set of [nodes]
 def computeKeyRate(G, nodes, key):
     total = 0
     rate = dict()

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -497,7 +497,7 @@ if __name__ == "__main__":
     parser.add_argument('--maxpropreads', action='store', type=int, default=0.1, help='Edges joining communities must have fewer than this number of UMIs as proportion of the smaller community they bridge')
 
     key_arg = parser.add_argument("--transfectionKey", action="store", type=str, default=None, help="Attribute key used to identify BCs transfections")
-    parser.add_argument("--cleanCellsMaxConflictRate", action="store", type=float, default=None, help="Removes edges of non-majority transfection from conflict cells with at most this UMI rate of non-majority transfection. It requires `transfectionKey`")
+    parser.add_argument("--removeMinorityBCsFromConflictingCells", action="store", type=float, default=None, help="For cells with BCs from more than one transfection, removes BCs from minority transfections that together represent at most this proportion of UMIs for that cell. Requires `transfectionKey`")
     parser.add_argument("--removeConflictingCells", action='store_true', default=False, help="Removes cells linked to BCs from 2+ transfections. It requires `transfectionKey`")
 
     parser.add_argument('--printGraph', action='store', type=str, help='Plot a graph for each clone into this directory')
@@ -507,8 +507,8 @@ if __name__ == "__main__":
     
     try:
         args = parser.parse_args()
-        if args.cleanCellsMaxConflictRate is not None and args.transfectionKey is None:
-            raise ArgumentError(key_arg, "`--transfectionKey` is required to use `--cleanCellsMaxConflictRate`")
+        if args.removeMinorityBCsFromConflictingCells is not None and args.transfectionKey is None:
+            raise ArgumentError(key_arg, "`--transfectionKey` is required to use `--removeMinorityBCsFromConflictingCells`")
         if args.transfectionKey is not None and args.removeConflictingCells and args.transfectionKey is None:
             raise ArgumentError(key_arg, "`--transfectionKey` is required to use `--removeConflictingCells`")
     except argparse.ArgumentError as exc:
@@ -562,8 +562,8 @@ if __name__ == "__main__":
     breakUpWeaklyConnectedCommunities(G, minCentrality=args.minCentrality, maxPropReads=args.maxpropreads, verbose=args.verbose, graphOutput=args.printGraph)
     
     clones = identifyClones(G)
-    if args.cleanCellsMaxConflictRate is not None:
-        pruneConflictingEdges(G, args.transfectionKey, args.cleanCellsMaxConflictRate)
+    if args.removeMinorityBCsFromConflictingCells is not None:
+        pruneConflictingEdges(G, args.transfectionKey, args.removeMinorityBCsFromConflictingCells)
     if args.transfectionKey is not None and args.removeConflictingCells:
         pruneConflictingCells(G, args.transfectionKey)
     writeOutputFiles(G, clones, args.output, args.outputlong, args.outputwide, args.cloneobj, args.printGraph)

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -201,8 +201,10 @@ def pruneConflictingEdges(G, transfectionKey, maxConflict):
         bcs = [x for (_, x) in G.edges(cell) if G.nodes[x][transfectionKey] not in skip]
         transfection_rate = computeKeyRate(G, bcs, transfectionKey)
         ## Skip cells with BCs from single transfection or no transfection and those with too high conflict rate
-        if len(transfection_rate) > 1 and (1 - transfection_rate[transfection_majority]) <= maxConflict:
+        if len(transfection_rate) > 1:
             transfection_majority = max(transfection_rate, key = transfection_rate.get)
+            if (1 - transfection_rate[transfection_majority]) > maxConflict:
+                continue
             keep = [transfection_majority] + skip
             edges_to_remove.update([(cell, x) for x in bcs if G.nodes[x][transfectionKey] not in keep])
     remove_edges(G, edges_to_remove)

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -497,8 +497,8 @@ if __name__ == "__main__":
     parser.add_argument('--maxpropreads', action='store', type=int, default=0.1, help='Edges joining communities must have fewer than this number of UMIs as proportion of the smaller community they bridge')
 
     parser.add_argument("--transfectionKey", action="store", type=str, default=None, help="Attribute key used to identify BCs transfections")
-    parser.add_argument("--maxConflictRate", action="store", type=float, default=None, help="Maximum non-majority transfection UMI rate to be remove from conflicting cells. It requires `transfectionKey` to execute")
-    parser.add_argument("--removeConflictingCells", action='store_true', default=False, help = "Removes conflict clones after all clean-up. It requires `transfectionKey` to execute")
+    parser.add_argument("--cleanCellsMaxConflictRate", action="store", type=float, default=None, help="Removes edges of non-majority transfection from conflict cells with at most this UMI rate of non-majority transfection. It requires `transfectionKey`")
+    parser.add_argument("--removeConflictingCells", action='store_true', default=False, help="Removes cells linked to BCs from 2+ transfections. It requires `transfectionKey`")
 
     parser.add_argument('--printGraph', action='store', type=str, help='Plot a graph for each clone into this directory')
     
@@ -558,14 +558,14 @@ if __name__ == "__main__":
     breakUpWeaklyConnectedCommunities(G, minCentrality=args.minCentrality, maxPropReads=args.maxpropreads, verbose=args.verbose, graphOutput=args.printGraph)
     
     clones = identifyClones(G)
-    if args.maxConflictRate is not None:
+    if args.cleanCellsMaxConflictRate is not None:
         if args.transfectionKey is not None:
             print("[genotypeClones] WARNING `--transfectionKey` is required to clean conflicting edges", file=sys.stderr)
         else:
-            pruneConflictingEdges(G, args.transfectionKey, args.maxConflictRate)
+            pruneConflictingEdges(G, args.transfectionKey, args.cleanCellsMaxConflictRate)
     if args.transfectionKey is not None and args.removeConflictingCells:
         if args.transfectionKey is not None:
             print("[genotypeClones] WARNING `--transfectionKey` is required to remove conflicting cells", file=sys.stderr)
         else:
-            pruneConflictingCells(G, args.transfectionKey, args.maxConflictRate)
+            pruneConflictingCells(G, args.transfectionKey)
     writeOutputFiles(G, clones, args.output, args.outputlong, args.outputwide, args.cloneobj, args.printGraph)

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -200,7 +200,7 @@ def pruneConflictingEdges(G, transfectionKey, maxConflict):
     for cell in [x for x in G.nodes if G.nodes[x]['type'] == "cell"]:
         bcs = [x for (_, x) in G.edges(cell) if G.nodes[x][transfectionKey] not in skip]
         transfection_rate = computeKeyRate(G, bcs, transfectionKey)
-        transfection_majority = max(transfection_rate, transfection_rate.get)
+        transfection_majority = max(transfection_rate, key = transfection_rate.get)
         ## Skip cells with BCs from single transfection or no transfection and those with too high conflict rate
         if len(transfection_rate) > 1 and (1 - transfection_rate[transfection_majority]) <= maxConflict:
             keep = [transfection_majority] + skip

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -178,7 +178,7 @@ def pruneEdgesLowPropOfReads(G, minPropOfBCReads, minPropOfCellReads):
     print("[genotypeClones] pruneEdgesLowPropOfReads - Removed ", len(edgesToRemove), " total edges", sep="", file=sys.stderr)
     pruneOrphanNodes(G)
 
-# Computes and return a dictionary of the [key] attribute value UMI proportion among a set of [nodes]
+# Within a set of nodes, return a dictionary mapping key attribute values to the proportion of total UMIs each attribute value represent
 def computeKeyRate(G, nodes, key):
     total = 0
     rate = dict()


### PR DESCRIPTION
Here, I am proposing a new interface to add the post clean-up of conflicting clones to `genotypeClones.py`.

- Replaced the previous interface and added three parameters:
   - `transfectionKey`, to determinate which attribute identifies BCs transfection
   - `maxConflictRate [rate]`, to determinate a maximum conflict rate for which we will try to recover conflicting cells
   - `removeConflictingCells`, a flag to determinate if after all should we remove conflict cells
- It uses two new functions for this clean-up `pruneConflictingEdges` and `pruneConflictingCells`.
- Removed the previous interface usage from `analyzeBCscounts.sh`