### PR TITLE
Permit passing separate bam file to count reads for normalization

### DIFF
--- a/dnase/bamintersect/HA_table.sh
+++ b/dnase/bamintersect/HA_table.sh
@@ -80,12 +80,6 @@ fi
 
 # Get the bam record lines for the read IDs with only one read in Zone 1.
 # Note that we will get two lines for each such read ID: one in Zone 1, and one in Zone 2.
-
-# Old:
-# ${src}/subsetBAM.py --exclude_flags ${exclude_flags} --readNames ${TMPDIR}/Reads.txt ${bamfile} ${TMPDIR}/subsetBAM_output.bam
-#
-# New (should have been changed in the Sep 10 series of changes):
-# "stop making .counts.informative.bed files as their utility is reduced"
 ${src}/subsetBAM.py --exclude_flags ${exclude_flags} --include_readnames ${TMPDIR}/Reads.txt ${bamfile} ${TMPDIR}/subsetBAM_output.bam
 
 # Need to sort & index here so we can filter by region below.

--- a/dnase/bamintersect/HA_table.sh
+++ b/dnase/bamintersect/HA_table.sh
@@ -80,7 +80,13 @@ fi
 
 # Get the bam record lines for the read IDs with only one read in Zone 1.
 # Note that we will get two lines for each such read ID: one in Zone 1, and one in Zone 2.
-${src}/subsetBAM.py --exclude_flags ${exclude_flags} --readNames ${TMPDIR}/Reads.txt ${bamfile} ${TMPDIR}/subsetBAM_output.bam
+
+# Old:
+# ${src}/subsetBAM.py --exclude_flags ${exclude_flags} --readNames ${TMPDIR}/Reads.txt ${bamfile} ${TMPDIR}/subsetBAM_output.bam
+#
+# New (should have been changed in the Sep 10 series of changes):
+# "stop making .counts.informative.bed files as their utility is reduced"
+${src}/subsetBAM.py --exclude_flags ${exclude_flags} --include_readnames ${TMPDIR}/Reads.txt ${bamfile} ${TMPDIR}/subsetBAM_output.bam
 
 # Need to sort & index here so we can filter by region below.
 samtools sort ${TMPDIR}/subsetBAM_output.bam > ${TMPDIR}/subsetBAM_output_sorted.bam

--- a/dnase/bamintersect/merge_bamintersect.sh
+++ b/dnase/bamintersect/merge_bamintersect.sh
@@ -62,16 +62,8 @@ debug_fa "Finished sorting dsgrep.bed"
 
 ##########################################################################################################
 ## Create the final output tables.
-
-if [ "${normbam}" = "NA" ]; then
-    #Unfiltered
-    num_bam1_reads=$(samtools view -c -F 512 ${bam1})
-    echo "Normalizing to 10M reads using bam1 read depth of ${num_bam1_reads}"
-else
-    num_bam1_reads=$(samtools view -c -F 512 ${normbam})
-    echo "Normalizing to 10M reads using ${normbam} read depth of ${num_bam1_reads}"
-fi
-
+num_bam1_reads=$(samtools view -c -F 512 ${normbam})
+echo "Normalizing to 10M reads using ${normbam} read depth of ${num_bam1_reads}"
 
 echo "Applying counts_table_mask"
 #Starts out with bam1 coordinates

--- a/dnase/bamintersect/merge_bamintersect.sh
+++ b/dnase/bamintersect/merge_bamintersect.sh
@@ -16,6 +16,8 @@ INTERMEDIATEDIR=$6
 bam1=$7
 bam2=$8
 verbose=$9
+normbam=${10}
+
 
 ## This function implements verbose output for debugging purposes.
 debug_fa() {
@@ -61,9 +63,15 @@ debug_fa "Finished sorting dsgrep.bed"
 ##########################################################################################################
 ## Create the final output tables.
 
-#Unfiltered
-num_bam1_reads=$(samtools view -c -F 512 ${bam1})
-echo "Normalizing to 10M reads using bam1 read depth of ${num_bam1_reads}"
+if [ "${normbam}" = "NA" ]; then
+    #Unfiltered
+    num_bam1_reads=$(samtools view -c -F 512 ${bam1})
+    echo "Normalizing to 10M reads using bam1 read depth of ${num_bam1_reads}"
+else
+    echo "Using special read normalization value."
+    echo "Normalizing to 10M reads using normbam read depth of ${num_bam1_reads}"
+    num_bam1_reads="${normbam}"
+fi
 
 
 echo "Applying counts_table_mask"

--- a/dnase/bamintersect/merge_bamintersect.sh
+++ b/dnase/bamintersect/merge_bamintersect.sh
@@ -16,7 +16,7 @@ INTERMEDIATEDIR=$6
 bam1=$7
 bam2=$8
 verbose=$9
-normbam=${10}
+normbam=$10
 
 ## This function implements verbose output for debugging purposes.
 debug_fa() {

--- a/dnase/bamintersect/merge_bamintersect.sh
+++ b/dnase/bamintersect/merge_bamintersect.sh
@@ -18,7 +18,6 @@ bam2=$8
 verbose=$9
 normbam=${10}
 
-
 ## This function implements verbose output for debugging purposes.
 debug_fa() {
     if [ ${verbose} = "True" ]; then

--- a/dnase/bamintersect/merge_bamintersect.sh
+++ b/dnase/bamintersect/merge_bamintersect.sh
@@ -62,7 +62,7 @@ debug_fa "Finished sorting dsgrep.bed"
 ##########################################################################################################
 ## Create the final output tables.
 num_bam1_reads=$(samtools view -c -F 512 ${normbam})
-echo "Normalizing to 10M reads using ${normbam} read depth of ${num_bam1_reads}"
+echo "Normalizing to 10M reads using read depth of ${num_bam1_reads} from ${normbam}"
 
 echo "Applying counts_table_mask"
 #Starts out with bam1 coordinates

--- a/dnase/bamintersect/merge_bamintersect.sh
+++ b/dnase/bamintersect/merge_bamintersect.sh
@@ -15,8 +15,8 @@ bam2genome=$5
 INTERMEDIATEDIR=$6
 bam1=$7
 bam2=$8
-verbose=$9
-normbam=$10
+normbam=$9
+verbose=$10
 
 ## This function implements verbose output for debugging purposes.
 debug_fa() {
@@ -61,8 +61,8 @@ debug_fa "Finished sorting dsgrep.bed"
 
 ##########################################################################################################
 ## Create the final output tables.
+echo "Normalizing to 10M reads using read depth from ${normbam}"
 num_bam1_reads=$(samtools view -c -F 512 ${normbam})
-echo "Normalizing to 10M reads using read depth of ${num_bam1_reads} from ${normbam}"
 
 echo "Applying counts_table_mask"
 #Starts out with bam1 coordinates

--- a/dnase/bamintersect/merge_bamintersect.sh
+++ b/dnase/bamintersect/merge_bamintersect.sh
@@ -68,9 +68,8 @@ if [ "${normbam}" = "NA" ]; then
     num_bam1_reads=$(samtools view -c -F 512 ${bam1})
     echo "Normalizing to 10M reads using bam1 read depth of ${num_bam1_reads}"
 else
-    echo "Using special read normalization value."
-    echo "Normalizing to 10M reads using normbam read depth of ${num_bam1_reads}"
-    num_bam1_reads="${normbam}"
+    num_bam1_reads=$(samtools view -c -F 512 ${normbam})
+    echo "Normalizing to 10M reads using ${normbam} read depth of ${num_bam1_reads}"
 fi
 
 

--- a/dnase/bamintersect/submit_bamintersect.sh
+++ b/dnase/bamintersect/submit_bamintersect.sh
@@ -92,6 +92,10 @@ Usage: $(basename "$0") [Options]
            # If unset, reads are paired like [read1 read2], or [read2 read1].
            # Set this option for unpaired reads.
            # The default is to have it unset.
+
+     --normbam {number of reads for normalization}
+           # Used in merge_bamintersect.sh
+           # Optional.  Default us number of reads in bam1
     
      --verbose {no argument}
            # Prints out debugging statements
@@ -126,6 +130,7 @@ long_arg_list=(
     bam2_exclude_flags:
     max_mismatches:
     reads_match
+    normbam
     verbose
     help
 )
@@ -174,6 +179,7 @@ eval set -- "${options}"
     bam2_exclude_flags="3076"
     verbose=False
     max_mismatches=1
+    normbam="NA"
 
 
 # Extract options and their arguments into variables.
@@ -205,6 +211,8 @@ while true ; do
             max_mismatches=$2 ; shift 1 ;;
         --reads_match)
             reads_match="--reads_match" ;;
+        --normbam)
+            normbam=$2 ; shift 1 ;;
         --verbose)
             verbose=True ;;
         -h|--help) usage; exit 0 ;;
@@ -426,7 +434,7 @@ rm -f ${sampleOutdir}/sgeid.sort_bamintersect_1.${sample_name} ${sampleOutdir}/s
 echo
 echo "merge_bamintersect"
 
-qsub -S /bin/bash -cwd ${qsubargs} -terse -j y -hold_jid `cat ${sampleOutdir}/sgeid.bamintersect.${sample_name}` -N merge_bamintersect.${sample_name} -o ${sampleOutdir}/log "${src}/merge_bamintersect.sh ${sampleOutdir} ${src} ${sample_name} ${bam1genome} ${bam2genome} ${INTERMEDIATEDIR} ${bam1} ${bam2} ${verbose}" > /dev/null
+qsub -S /bin/bash -cwd ${qsubargs} -terse -j y -hold_jid `cat ${sampleOutdir}/sgeid.bamintersect.${sample_name}` -N merge_bamintersect.${sample_name} -o ${sampleOutdir}/log "${src}/merge_bamintersect.sh ${sampleOutdir} ${src} ${sample_name} ${bam1genome} ${bam2genome} ${INTERMEDIATEDIR} ${bam1} ${bam2} ${verbose} ${normbam}" > /dev/null
 rm -f ${sampleOutdir}/sgeid.bamintersect.${sample_name}
 
 echo

--- a/dnase/bamintersect/submit_bamintersect.sh
+++ b/dnase/bamintersect/submit_bamintersect.sh
@@ -238,7 +238,7 @@ if [ ${ierr} = "1" ]; then
 fi
 
 if [ "${normbam}" = "NA" ]; then
-    normbam=${bam1}
+    normbam="${bam1}"
 fi
 
 # End of getopt section.
@@ -264,15 +264,20 @@ mkdir -p ${INTERMEDIATEDIR}/sorted_bams
 echo "Running on $HOSTNAME. Using $TMPDIR as tmp"
 
 
-if [ ! -s ${bam1} ]; then
+if [ ! -s "${bam1}" ]; then
     echo "ERROR: Could not find bam1 file ${bam1}"
-    exit 1
+    exit 2
 fi
 
-if [ ! -s ${bam2} ]; then
+if [ ! -s "${bam2}" ]; then
     echo "ERROR: Could not find bam2 file ${bam2}"
-    exit 1
+    exit 3
 fi
+
+if [ ! -s "${normbam}" ]; then
+    echo "ERROR Can not find normalization bam file ${normbam}."
+    exit 4
+ fi
 
 
 ################################################################################################
@@ -437,7 +442,7 @@ rm -f ${sampleOutdir}/sgeid.sort_bamintersect_1.${sample_name} ${sampleOutdir}/s
 echo
 echo "merge_bamintersect"
 
-qsub -S /bin/bash -cwd ${qsubargs} -terse -j y -hold_jid `cat ${sampleOutdir}/sgeid.bamintersect.${sample_name}` -N merge_bamintersect.${sample_name} -o ${sampleOutdir}/log "${src}/merge_bamintersect.sh ${sampleOutdir} ${src} ${sample_name} ${bam1genome} ${bam2genome} ${INTERMEDIATEDIR} ${bam1} ${bam2} ${verbose} ${normbam}" > /dev/null
+qsub -S /bin/bash -cwd ${qsubargs} -terse -j y -hold_jid `cat ${sampleOutdir}/sgeid.bamintersect.${sample_name}` -N merge_bamintersect.${sample_name} -o ${sampleOutdir}/log "${src}/merge_bamintersect.sh ${sampleOutdir} ${src} ${sample_name} ${bam1genome} ${bam2genome} ${INTERMEDIATEDIR} ${bam1} ${bam2} ${normbam} ${verbose}" > /dev/null
 rm -f ${sampleOutdir}/sgeid.bamintersect.${sample_name}
 
 echo

--- a/dnase/bamintersect/submit_bamintersect.sh
+++ b/dnase/bamintersect/submit_bamintersect.sh
@@ -93,9 +93,9 @@ Usage: $(basename "$0") [Options]
            # Set this option for unpaired reads.
            # The default is to have it unset.
 
-     --normbam {number of reads for normalization}
+     --normbam {bam file which will be used to count reads for normalization}
            # Used in merge_bamintersect.sh
-           # Optional.  Default us number of reads in bam1
+           # Optional.  Default is to use the bam1 file.
     
      --verbose {no argument}
            # Prints out debugging statements

--- a/dnase/bamintersect/submit_bamintersect.sh
+++ b/dnase/bamintersect/submit_bamintersect.sh
@@ -92,10 +92,9 @@ Usage: $(basename "$0") [Options]
            # If unset, reads are paired like [read1 read2], or [read2 read1].
            # Set this option for unpaired reads.
            # The default is to have it unset.
-
+    
      --normbam {bam file which will be used to count reads for normalization}
-           # Used in merge_bamintersect.sh
-           # Optional.  Default is to use the bam1 file.
+           # Optional, default is to use the bam1 file.
     
      --verbose {no argument}
            # Prints out debugging statements

--- a/dnase/bamintersect/submit_bamintersect.sh
+++ b/dnase/bamintersect/submit_bamintersect.sh
@@ -130,7 +130,7 @@ long_arg_list=(
     bam2_exclude_flags:
     max_mismatches:
     reads_match
-    normbam
+    normbam:
     verbose
     help
 )

--- a/dnase/bamintersect/submit_bamintersect.sh
+++ b/dnase/bamintersect/submit_bamintersect.sh
@@ -238,6 +238,10 @@ if [ ${ierr} = "1" ]; then
     exit 1
 fi
 
+if [ "${normbam}" = "NA" ]; then
+    normbam=${bam1}
+fi
+
 # End of getopt section.
 ################################################
 sample_name="${sample_name}.${bam1genome}_vs_${bam2genome}"

--- a/dnase/submit.sh
+++ b/dnase/submit.sh
@@ -179,8 +179,15 @@ if [ "${runBamIntersect}" -eq 1 ] && ([[ "${processingCommand}" == "bamintersect
                     bamIntersectHold=""
                 fi
                 
+                #Hardcode the bamfile used to determine read counts for normalization
+                if [[ "${mammalianGenome}"=="LPICE" ]]; then
+                    normbam="--normbam ${sampleOutdir}/${name}.mm10.bam"
+                else
+                    normbam=""
+                fi
+                
                 mkdir -p ${sampleOutdir}/bamintersect/log
-                qsub -S /bin/bash -cwd -V ${qsubargs} -terse -j y -b y ${bamIntersectHold} -o ${sampleOutdir}/bamintersect/log -N submit_bamintersect.${name}.${mammalianAnnotationGenome}_vs_${cegsGenomeShort} "${src}/bamintersect/submit_bamintersect.sh --sample_name ${name} --outdir ${sampleOutdir}/bamintersect --bam1 ${sampleOutdir}/${name}.${mammalianGenome}.bam --bam1genome ${mammalianAnnotationGenome} --bam2 ${sampleOutdir}/${name}.${cegsGenome}.bam --bam2genome ${cegsGenomeShort} --integrationsite ${integrationsite}" > /dev/null
+                qsub -S /bin/bash -cwd -V ${qsubargs} -terse -j y -b y ${bamIntersectHold} -o ${sampleOutdir}/bamintersect/log -N submit_bamintersect.${name}.${mammalianAnnotationGenome}_vs_${cegsGenomeShort} "${src}/bamintersect/submit_bamintersect.sh --sample_name ${name} --outdir ${sampleOutdir}/bamintersect --bam1 ${sampleOutdir}/${name}.${mammalianGenome}.bam --bam1genome ${mammalianAnnotationGenome} --bam2 ${sampleOutdir}/${name}.${cegsGenome}.bam --bam2genome ${cegsGenomeShort} --integrationsite ${integrationsite} ${normbam}" > /dev/null
             fi
         done
     done

--- a/dnase/submit.sh
+++ b/dnase/submit.sh
@@ -180,7 +180,7 @@ if [ "${runBamIntersect}" -eq 1 ] && ([[ "${processingCommand}" == "bamintersect
                 fi
                 
                 #Hardcode the bamfile used to determine read counts for normalization
-                if [[ "${mammalianGenome}" == "LPICE" ]]; then
+                if [[ "${mammalianGenome}" == "cegsvectors_LPICE" ]]; then
                     normbam="--normbam ${sampleOutdir}/${name}.mm10.bam"
                 else
                     normbam=""

--- a/dnase/submit.sh
+++ b/dnase/submit.sh
@@ -180,7 +180,7 @@ if [ "${runBamIntersect}" -eq 1 ] && ([[ "${processingCommand}" == "bamintersect
                 fi
                 
                 #Hardcode the bamfile used to determine read counts for normalization
-                if [[ "${mammalianGenome}"=="LPICE" ]]; then
+                if [[ "${mammalianGenome}" == "LPICE" ]]; then
                     normbam="--normbam ${sampleOutdir}/${name}.mm10.bam"
                 else
                     normbam=""


### PR DESCRIPTION
The optional normbam parameter is passed to merge_bamintersect.sh, and is used there instead of bam1 as the basis for counting reads for normalization.

Also fixed a typo in HA_table.sh   --readNames ==> --include_readnames
This change was overlooked in the "stop making .counts.informative.bed files as their utility is reduced" commit.

fixes #228 