### PR TITLE
Genotype clones fixes

### DIFF
--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -144,6 +144,7 @@ def pruneOrphanNodes(G):
 def remove_edges(G, edgesToRemove):
     #Convert to set to speed-up inclusion check
     edgesToRemove = set(edgesToRemove)
+    edgesToRemove.update([(y, x) for (x, y) in edgesToRemove])
     #Update node weights first
     #Make sure we only subtract umis once per edge, regardless of representation (i.e. node order) in edgesToRemove
     for edge in [e for e in G.edges if e in edgesToRemove]:

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -144,6 +144,7 @@ def pruneOrphanNodes(G):
 def remove_edges(G, edgesToRemove):
     #Convert to set to speed-up inclusion check
     edgesToRemove = set(edgesToRemove)
+    #Also include the edges in the reverse order [(x, y) => (y, x)] to make sure they match the edges emited by G.edges
     edgesToRemove.update([(y, x) for (x, y) in edgesToRemove])
     #Update node weights first
     #Make sure we only subtract umis once per edge, regardless of representation (i.e. node order) in edgesToRemove

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -180,15 +180,16 @@ def pruneEdgesLowPropOfReads(G, minPropOfBCReads, minPropOfCellReads):
     print("[genotypeClones] pruneEdgesLowPropOfReads - Removed ", len(edgesToRemove), " total edges", sep="", file=sys.stderr)
     pruneOrphanNodes(G)
 
-# Within a set of nodes, return a dictionary mapping key attribute values to the proportion of total UMIs each attribute value represent
-def computeKeyRate(G, nodes, key):
+# Within a set of destiny nodes and a source node, return a dictionary mapping key attribute values to the proportion of total UMIs each attribute value represent
+def computeKeyRate(G, source, dest, key):
     total = 0
     rate = dict()
     ## Count UMI per key value
-    for x in nodes:
-        total += G.nodes[x]['weight']
+    for x in dest:
         value = G.nodes[x][key]
-        rate[value] = rate.get(value, 0) + G.nodes[x]['weight']
+        weight = G.edges[(source, x)]["weight"]
+        total += weight
+        rate[value] = rate.get(value, 0) + weight
     ## Compute rate by key value
     for value in rate.keys():
         rate[value] /= total
@@ -201,7 +202,7 @@ def pruneConflictingEdges(G, transfectionKey, maxConflict):
     skip = ["conflicting", "uninformative", "None"]
     for cell in [x for x in G.nodes if G.nodes[x]['type'] == "cell"]:
         bcs = [x for (_, x) in G.edges(cell) if G.nodes[x][transfectionKey] not in skip]
-        transfection_rate = computeKeyRate(G, bcs, transfectionKey)
+        transfection_rate = computeKeyRate(G, cell, bcs, transfectionKey)
         ## Skip cells with BCs from single transfection or no transfection and those with too high conflict rate
         if len(transfection_rate) > 1:
             transfection_majority = max(transfection_rate, key = transfection_rate.get)


### PR DESCRIPTION
Hi,
upon reviewing the `genotypeClones.py` code results I noticed two bugs that I commit solutions here:

- `computeKeyRate` was using the BCs total weight instead of the edge weight to estimate the transfections rate. I included a `source`  parameter to determine the edges and correctly compute the rates.
- `remove_edges` was excluding edges twice or not decreasing the node's total weight of some edges were being excluded making the total weight inconsistent with the sum of the weight of the edges. As `G.edges` emit edges on arbitrary order (either (BC, cellBC) or (cellBC, BC)) sometimes they were not recognized as included to `edgesToRemove`. To fix this I've added the reverted order to `edgesToRemove` which accounts for either cases and guarantees consistency.
