### PR TITLE
fixPruneConflictNodesBug

### DIFF
--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -229,9 +229,9 @@ def pruneConflictingNodes(G, transfectionKey, type = "BC"):
             neighborhood.update(G.neighbors(node))
         neighborhood_transfection = set([G.nodes[x][transfectionKey] for x in neighborhood]) - skip
         if len(neighborhood_transfection) > 1:
-            nodes_to_remove.add(bc)
+            nodes_to_remove.add(node)
     edges_to_remove = list(G.edges(nodes_to_remove))
-    remove_edges(G, nodes_to_remove)
+    remove_edges(G, edges_to_remove)
     G.remove_nodes_from(nodes_to_remove)
     print("[genotypeClones] pruneConflictingNodes - Removed ", len(edges_to_remove), " edges", sep="", file=sys.stderr)
     print("[genotypeClones] pruneConflictingNodes - Removed ", len(nodes_to_remove), " nodes", sep="", file=sys.stderr)


### PR DESCRIPTION
This is a fix for two bugs raised when running `pruneConflictingNodes` from `genotypeClones.py`. The following errors were raised during test-run

(1) 
```
Traceback (most recent call last):
  File "/vol/mauranolab/mapped/src/transposon/genotypeClones.py", line 565, in <module>
    pruneConflictingNodes(G, args.transfectionKey, type = "cell")
  File "/vol/mauranolab/mapped/src/transposon/genotypeClones.py", line 232, in pruneConflictingNodes
    nodes_to_remove.add(bc)
NameError: name 'bc' is not defined
```

(2)
```
Traceback (most recent call last):
  File "/vol/mauranolab/ribeia01/transposon_10x/mapping/transposon/genotypeClones.py", line 567, in <module>
    pruneConflictingNodes(G, args.transfectionKey, type = "BC")
  File "/vol/mauranolab/ribeia01/transposon_10x/mapping/transposon/genotypeClones.py", line 234, in pruneConflictingNodes
    remove_edges(G, nodes_to_remove)
  File "/vol/mauranolab/ribeia01/transposon_10x/mapping/transposon/genotypeClones.py", line 147, in remove_edges
    edgesToRemove.update([(y, x) for (x, y) in edgesToRemove])
  File "/vol/mauranolab/ribeia01/transposon_10x/mapping/transposon/genotypeClones.py", line 147, in <listcomp>
    edgesToRemove.update([(y, x) for (x, y) in edgesToRemove])
ValueError: too many values to unpack (expected 2)
```

They were caused be the use of the wrong variable reference, which are now fixed.