### PR TITLE
Add no bc support to ipcr mapping

### DIFF
--- a/transposon/analyzeIntegrations.sh
+++ b/transposon/analyzeIntegrations.sh
@@ -26,6 +26,12 @@ minReadCutoff=2
 
 OUTDIR=${sample}
 
+
+if [ ! -s "$OUTDIR/${sample}.barcodes.txt.gz" ]; then
+    echo "analyzeIntegrations.sh ERROR: barcode input file $OUTDIR/${sample}.barcodes.txt does not exist!"
+    exit 1
+fi
+
 if [ ! -s "$OUTDIR/${sample}.bam" ]; then
     echo "analyzeIntegrations.sh ERROR: mapped reads input file $OUTDIR/${sample}.bam does not exist!"
     exit 2
@@ -38,7 +44,9 @@ hg38_noalt)
     hotspotfile=/vol/isg/encode/dnase/mapped/K562-DS9764/hotspots/K562-DS9764.hg38_noalt-final/K562-DS9764.hg38_noalt.fdr0.01.pks.starch;
     chromsizes=/vol/isg/annotation/fasta/hg38_noalt/hg38_noalt.chrom.sizes;;
 mm10)
-    chromsizes=/vol/isg/annotation/fasta/mm10/mm10.chrom.sizesl;;
+    # FIX hard-coded references to humam genome reference
+    hotspotfile=/vol/isg/encode/dnase/mapped/K562-DS9764/hotspots/K562-DS9764.hg38_noalt-final/K562-DS9764.hg38_noalt.fdr0.01.pks.starch;
+    chromsizes=/vol/isg/annotation/fasta/mm10/mm10.chrom.sizes;;
 *)
     echo "Don't recognize genome ${curGenome}";
     exit 3;;
@@ -116,17 +124,13 @@ cat $TMPDIR/${sample}.coords.bed | wc -l
 echo -n -e "${sample}\tNumber of pairedreads mapped passing all filters\t"
 samtools view -c ${samflags} -f 1 $OUTDIR/${sample}.bam
 
-if [ -s "$OUTDIR/${sample}.barcodes.txt.gz" ]; then
-    zcat -f $OUTDIR/${sample}.barcodes.txt.gz | awk -F "\t" 'BEGIN {OFS="\t"} $1!=""' | sort -k2,2 > $TMPDIR/${sample}.barcodes.txt
-    cat $TMPDIR/${sample}.coords.bed | sort -k4,4 | join -1 4 -2 2 - $TMPDIR/${sample}.barcodes.txt | awk 'BEGIN {OFS="\t"} {print $2, $3, $4, $1, $6, $7, $8}' | sort-bed - > $TMPDIR/${sample}.barcodes.readnames.coords.raw.bed
-    #columns: chrom, start, end, readID, strand, BC seq, UMI
-    #NB strand in $5
-    echo -e -n "${sample}\tNumber of reads passing all filters and having barcodes assigned\t"
-    cat $TMPDIR/${sample}.barcodes.readnames.coords.raw.bed | wc -l
-else
-    cat $TMPDIR/${sample}.coords.bed | awk 'BEGIN {OFS="\t"} {print $1, $2, $3, $4, $6, "NA", "NA"}' > $TMPDIR/${sample}.barcodes.readnames.coords.raw.bed
-    #columns: chrom, start, end, readID, strand, BC seq, UMI
-fi
+zcat -f $OUTDIR/${sample}.barcodes.txt.gz | awk -F "\t" 'BEGIN {OFS="\t"} $1!=""' | sort -k2,2 > $TMPDIR/${sample}.barcodes.txt
+cat $TMPDIR/${sample}.coords.bed | sort -k4,4 | join -1 4 -2 2 - $TMPDIR/${sample}.barcodes.txt | awk 'BEGIN {OFS="\t"} {print $2, $3, $4, $1, $6, $7, $8}' | sort-bed - > $TMPDIR/${sample}.barcodes.readnames.coords.raw.bed
+#columns: chrom, start, end, readID, strand, BC seq, UMI
+#NB strand in $5
+echo -e -n "${sample}\tNumber of reads passing all filters and having barcodes assigned\t"
+cat $TMPDIR/${sample}.barcodes.readnames.coords.raw.bed | wc -l
+
 
 echo
 echo "Histogram of barcode reads before coordinate-based deduping"
@@ -266,7 +270,7 @@ cat $TMPDIR/${sample}.barcodes.coords.minReadCutoff.bed | awk -F "\t" 'BEGIN {OF
 #Identify insertion sites with more than one BC
 cat $TMPDIR/${sample}.barcodes.coords.minReadCutoff.bed | awk -F "\t" 'BEGIN {OFS="\t"} {$4="."; $5=0; print}' | uniq -c | awk 'BEGIN {OFS="\t"} $1==1 {print $2, $3, $4, $5, $6, $7}' | sort-bed - > $TMPDIR/${sample}.singleBC.bed
 
-if [ -s "$OUTDIR/${sample}.barcodes.txt.gz" ]; then
+if [ $(wc -l $TMPDIR/${sample}.singleIns.txt) -gt 0 ]; then
     cat $TMPDIR/${sample}.barcodes.coords.minReadCutoff.bed |
     #Remove BCs with more than one location
     awk -F "\t" 'BEGIN {OFS="\t"} NR==FNR{a[$1];next} ($4) in a' $TMPDIR/${sample}.singleIns.txt - |

--- a/transposon/extractBCcounts.sh
+++ b/transposon/extractBCcounts.sh
@@ -19,13 +19,6 @@ bclen=$3
 chunksize=$4
 plasmidSeq=$5
 
-if [[ $bclen -le 0 ]]; then
-    echo "Skipping extractBCcounts.sh, since `bclen` is 0"
-    echo
-    echo "Done!!!"
-    date
-    exit 0
-fi
 
 #Just take the rest to simplify passing multiple arguments for extractBarcode.py
 shift 5

--- a/transposon/extractBCcounts.sh
+++ b/transposon/extractBCcounts.sh
@@ -19,6 +19,14 @@ bclen=$3
 chunksize=$4
 plasmidSeq=$5
 
+if [[ $bclen -le 0 ]]; then
+    echo "Skipping extractBCcounts.sh, since `bclen` is 0"
+    echo
+    echo "Done!!!"
+    date
+    exit 0
+fi
+
 #Just take the rest to simplify passing multiple arguments for extractBarcode.py
 shift 5
 extractBCargs=$@

--- a/transposon/extractBarcode.py
+++ b/transposon/extractBarcode.py
@@ -131,9 +131,14 @@ minBaseQ = args.minBaseQ
 
 bcRefSeq = args.bcRefSeq.upper()
 bc_pos_match = re.search('B+', bcRefSeq)
-bcRefSeq_bc_start = bc_pos_match.start()
-bcRefSeq_bc_end = bc_pos_match.end()
-bcRefSeq_bc_len = bcRefSeq_bc_end - bcRefSeq_bc_start
+if bc_pos_match is not None:
+    bcRefSeq_bc_start = bc_pos_match.start()
+    bcRefSeq_bc_end = bc_pos_match.end()
+    bcRefSeq_bc_len = bcRefSeq_bc_end - bcRefSeq_bc_start
+else:
+    bcRefSeq_bc_start = 0
+    bcRefSeq_bc_end = 0
+    bcRefSeq_bc_len = 0
 bcRefSeqLength = len(bcRefSeq)
 
 #These will stay 0 unless we are in --align mode
@@ -307,6 +312,8 @@ try:
         
         
         if readBCreadEditDistPassed and readBCMinBaseQpassed and readBClengthPassed and readNoNsInBCPassed and (not enforcePlasmidRead or readPlasmidReadEditDistPassed) and (not args.align or readAlignmentPassed):
+            if bc_seq == "":
+                bc_seq = "NoBC"
             #Read is good
             print(bc_seq, readname[0], UMI_seq, cell_seq, sep="\t")
         else:

--- a/transposon/mapIntegrations.sh
+++ b/transposon/mapIntegrations.sh
@@ -74,9 +74,10 @@ esac
 ###Now set up for the iPCR-specific parts
 #Trim primer before mapping to genome
 #R1 will get trimmed if PE mapping is selected
-#BUGBUG hardcoded primer lengths
-R1primerlen=45
-R2primerlen=18
+#BUGBUG hardcoded primer lengths. FIXED BY using sequence template as base length
+R1primerlen=$(expr $(echo -n ${BCreadSeq} | wc -c) - 4)
+R2primerlen=$(echo -n ${plasmidSeq} | wc -c)
+minR1Len=$(expr ${R1primerlen} + 24)
 # R1 read adapters
 #BUGBUG move this so it isn't hard coded
 altDpnSeq="GATCTTTGTCCAAACTCATCGAGCTCGG"
@@ -87,8 +88,8 @@ altDpnRevSeq=$(echo ${altDpnSeq} | tr "[ATGC]" "[TACG]" | rev)
 
 echo
 date
-## Require BC read have 49 + 20 bp length to run paired mapping
-if [ "$(zcat -f $f1 | head -n 4000 | awk 'NR % 4 == 2 { sum += length($0) }; END { print 4 * sum/NR }')" -le 69 ]; then
+## Require BC read have R1primerlen + 20 bp length to run paired mapping
+if [ "$(zcat -f $f1 | head -n 4000 | awk 'NR % 4 == 2 { sum += length($0) }; END { print 4 * sum/NR }')" -le $minR1Len ]; then
 
     echo "Trimming $R2primerlen bp primer from R2"
     zcat -f $f2 | 

--- a/transposon/removeOverrepresentedBCs.py
+++ b/transposon/removeOverrepresentedBCs.py
@@ -15,12 +15,12 @@ def process_lines(input_data, wr):
     #Don't include failed BCs in further counts
     del myCounts['']
     totalBCs = sum(myCounts.values())
-     
+    
     if args.verbose:
         print("\nNumber of unique barcodes:", totalBCs, file=sys.stderr)
         print("The 10 most common BCs before removal:", myCounts.most_common(10), file=sys.stderr)
     
-    failedBCs = [x for x in myCounts.keys() if myCounts[x] / totalBCs > freq]
+    failedBCs = [x for x in myCounts.keys() if myCounts[x] / totalBCs > freq and x != "NoBC"]
     
     print("[removeOverrepresentedBCs] Number of barcodes removed:", len(failedBCs), file=sys.stderr)
     

--- a/transposon/submit.sh
+++ b/transposon/submit.sh
@@ -261,11 +261,9 @@ if [ ${runMerge} -eq 1 ]; then
     cat <<EOF | qsub -S /bin/bash -j y -b y -N merge.${sample} -o ${OUTDIR} -terse ${mergeHold} | perl -pe 's/[^\d].+$//g;' > sgeid.merge.${sample}
     set -eu -o pipefail
     echo "Merging barcodes"
-    if [[ ${bclen} -gt 0 ]]; then
-        zcat -f ${bcfiles} | pigz -p ${NSLOTS} -c -9 > $OUTDIR/${sample}.barcodes.preFilter.txt.gz
-        rm -f ${bcfiles}
-    fi
-    
+
+    zcat -f ${bcfiles} | pigz -p ${NSLOTS} -c -9 > $OUTDIR/${sample}.barcodes.preFilter.txt.gz
+    rm -f ${bcfiles}
     if [[ ${sampleType} == "iPCR" ]]; then
         echo "Merging bam files"
         if [[ `echo ${bamfiles} | wc | awk '{print $2}'` -gt 1 ]]; then 
@@ -301,16 +299,12 @@ fi
 cat <<EOF | qsub -S /bin/bash -j y -b y -N ${sample} -terse ${analysisHold} # | perl -pe 's/[^\d].+$//g;' > sgeid.analysis
 set -eu -o pipefail
 
-if [[ ${bclen} -gt 0 ]]; then
-    ${src}/analyzeBCcounts.sh ${minReadCutoff} ${sample}
-fi
-
+${src}/analyzeBCcounts.sh ${minReadCutoff} ${sample}
 if [[ ${sampleType} == "iPCR" ]]; then
     ${src}/analyzeIntegrations.sh ${sample}
 fi
 EOF
 rm -f sgeid.merge.${sample}
-
 
 echo "Done!!!"
 date

--- a/transposon/submit.sh
+++ b/transposon/submit.sh
@@ -303,10 +303,10 @@ set -eu -o pipefail
 
 if [[ ${bclen} -gt 0 ]]; then
     ${src}/analyzeBCcounts.sh ${minReadCutoff} ${sample}
+fi
 
-    if [[ ${sampleType} == "iPCR" ]]; then
-        ${src}/analyzeIntegrations.sh ${sample}
-    fi
+if [[ ${sampleType} == "iPCR" ]]; then
+    ${src}/analyzeIntegrations.sh ${sample}
 fi
 EOF
 rm -f sgeid.merge.${sample}

--- a/transposon/submitMerge.sh
+++ b/transposon/submitMerge.sh
@@ -91,10 +91,10 @@ set -eu -o pipefail
 
 if [[ ${bclen} -gt 0 ]]; then
     ${src}/analyzeBCcounts.sh ${minReadCutoff} ${sample}
+fi
 
-    if [[ ${sampleType} == "iPCR" ]]; then
-        ${src}/analyzeIntegrations.sh ${sample}
-    fi
+if [[ ${sampleType} == "iPCR" ]]; then
+    ${src}/analyzeIntegrations.sh ${sample}
 fi
 EOF
 rm -f sgeid.merge.${sample}

--- a/transposon/submitMerge.sh
+++ b/transposon/submitMerge.sh
@@ -56,7 +56,10 @@ if [ ${runMerge} -eq 1 ]; then
     set -eu -o pipefail
     echo "Merging barcodes from files: ${bcfiles}"
     date
-    zcat -f ${bcfiles} | pigz -p ${NSLOTS} -c -9 > ${OUTDIR}/${sample}.barcodes.preFilter.txt.gz
+    
+    if [[ ${bclen} -gt 0 ]]; then
+        zcat -f ${bcfiles} | pigz -p ${NSLOTS} -c -9 > ${OUTDIR}/${sample}.barcodes.preFilter.txt.gz
+    fi
     
     if [[ ${sampleType} == "iPCR" ]]; then
         echo "Merging bam files"
@@ -85,10 +88,13 @@ fi
 #-o ${sample} breaks Jesper's Flowcell_Info.sh
 cat <<EOF | qsub -S /bin/bash -j y -b y -N ${sample} -terse ${analysisHold} | perl -pe 's/[^\d].+$//g;'  #> sgeid.analysis
 set -eu -o pipefail
-${src}/analyzeBCcounts.sh ${minReadCutoff} ${sample}
 
-if [[ ${sampleType} == "iPCR" ]]; then
-    ${src}/analyzeIntegrations.sh ${sample}
+if [[ ${bclen} -gt 0 ]]; then
+    ${src}/analyzeBCcounts.sh ${minReadCutoff} ${sample}
+
+    if [[ ${sampleType} == "iPCR" ]]; then
+        ${src}/analyzeIntegrations.sh ${sample}
+    fi
 fi
 EOF
 rm -f sgeid.merge.${sample}


### PR DESCRIPTION
Here I propose some changes to iPCR mapping pipeline to enable it to deal with iPCR with no BC sequence. A priori, I am skipping extractBCs.sh for such cases.
Besides that I've made mapIntegrations.sh trimming more adaptable to the primer sequence template given as parameter.