### PR TITLE
Adjust MakeTrackhub.py to read 9 columns from bb files.

### DIFF
--- a/dnase/trackhub/MakeTrackhub.py
+++ b/dnase/trackhub/MakeTrackhub.py
@@ -574,7 +574,7 @@ for assay_type in assays:
                             visibility="hide",
                             parentonoff="off",
                             tracktype="bigBed",
-                            maxItems=250,
+                            maxItems=2500,
                             short_label="Genotypes",
                             long_label="Genotypes")
                         composite.add_view(Genotypes_view)
@@ -584,7 +584,7 @@ for assay_type in assays:
                         long_label=assay_type + ' Genotypes ' + sampleDescription,
                         url=args.URLbase + urllib.parse.quote(curSample['filebase']) + '.genotypes.bb',
                         subgroups=sampleSubgroups,
-                        tracktype='bigBed 5 +',
+                        tracktype='bigBed 9 .',
                         color=curSample['Color'],
                         itemRgb="on",
                         parentonoff="off"

--- a/dnase/trackhub/MakeTrackhub.py
+++ b/dnase/trackhub/MakeTrackhub.py
@@ -574,7 +574,7 @@ for assay_type in assays:
                             visibility="hide",
                             parentonoff="off",
                             tracktype="bigBed",
-                            maxItems=2500,
+                            maxItems=100000,
                             short_label="Genotypes",
                             long_label="Genotypes")
                         composite.add_view(Genotypes_view)


### PR DESCRIPTION
This enables the itemRgb parameter.

I also changed maxItems to 2500 from 250.  When the number of items displayed from the bb file exceeds this value, the coloring is turned off.