### PR TITLE
Add configurable parameters to mapIntegrations.sh

### DIFF
--- a/transposon/analyzeIntegrations.sh
+++ b/transposon/analyzeIntegrations.sh
@@ -38,13 +38,16 @@ if [ ! -s "$OUTDIR/${sample}.bam" ]; then
 fi
 
 # BUG: hardcoded and dependent of genome
-curGenome="mm10"
+curGenome="hg38_noalt"
+#curGenome="mm10"
 case "${curGenome}" in
 hg38_noalt)
+    annotationgenome=hg38;
     hotspotfile=/vol/isg/encode/dnase/mapped/K562-DS9764/hotspots/K562-DS9764.hg38_noalt-final/K562-DS9764.hg38_noalt.fdr0.01.pks.starch;
     chromsizes=/vol/isg/annotation/fasta/hg38_noalt/hg38_noalt.chrom.sizes;;
 mm10)
     # FIX hard-coded references to humam genome reference
+    annotationgenome=mm10;
     hotspotfile=/vol/isg/encode/dnase/mapped/K562-DS9764/hotspots/K562-DS9764.hg38_noalt-final/K562-DS9764.hg38_noalt.fdr0.01.pks.starch;
     chromsizes=/vol/isg/annotation/fasta/mm10/mm10.chrom.sizes;;
 *)
@@ -288,7 +291,7 @@ echo
 echo "Generating UCSC track"
 projectdir=`pwd | perl -pe 's/^\/vol\/mauranolab\/transposon\///g;'`
 UCSCbaseURL="https://cascade.isg.med.nyu.edu/~mauram01/transposon/${projectdir}/${OUTDIR}"
-echo "track name=${sample} description=${sample}-integrations db=hg38 color=$trackcolor"
+echo "track name=${sample} description=${sample}-integrations db=${annotationgenome} color=$trackcolor"
 echo "${UCSCbaseURL}/${sample}.barcodes.coords.bed"
 
 
@@ -382,7 +385,7 @@ awk -F "\t" 'BEGIN {OFS="\t"} $5!=0' $TMPDIR/${sample}.insertions.density.bed | 
 #Kent tools can't use STDIN
 wigToBigWig $TMPDIR/${sample}.insertions.density.wig ${chromsizes} ${OUTDIR}/${sample}.insertions.density.bw
 
-echo "track name=${sample}-dens description=\"${sample}-density\" maxHeightPixels=30 color=$trackcolor viewLimits=0:100 autoScale=on visibility=full db=hg38 type=bigWig bigDataUrl=${UCSCbaseURL}/${sample}.insertions.density.bw"
+echo "track name=${sample}-dens description=\"${sample}-density\" maxHeightPixels=30 color=$trackcolor viewLimits=0:100 autoScale=on visibility=full db=${annotationgenome} type=bigWig bigDataUrl=${UCSCbaseURL}/${sample}.insertions.density.bw"
 
 
 echo

--- a/transposon/mapIntegrations.sh
+++ b/transposon/mapIntegrations.sh
@@ -72,12 +72,16 @@ esac
 
 
 ###Now set up for the iPCR-specific parts
+# Configurable parameters
+minLengthForPEmapping=24
+cutadaptR1args=""
+cutadaptR2args=""
 #Trim primer before mapping to genome
 #R1 will get trimmed if PE mapping is selected
 #BUGBUG hardcoded primer lengths. FIXED BY using sequence template as base length
 R1primerlen=$(expr $(echo -n ${BCreadSeq} | wc -c) - 4)
 R2primerlen=$(echo -n ${plasmidSeq} | wc -c)
-minR1Len=$(expr ${R1primerlen} + 24)
+minR1Len=$(expr ${R1primerlen} + ${minLengthForPEmapping})
 # R1 read adapters
 #BUGBUG move this so it isn't hard coded
 altDpnSeq="GATCTTTGTCCAAACTCATCGAGCTCGG"
@@ -94,7 +98,7 @@ if [ "$(zcat -f $f1 | head -n 4000 | awk 'NR % 4 == 2 { sum += length($0) }; END
     echo "Trimming $R2primerlen bp primer from R2"
     zcat -f $f2 | 
     awk -v firstline=$firstline -v lastline=$lastline 'NR>=firstline && NR<=lastline' |
-    cutadapt -j $NSLOTS -Z -o $TMPDIR/${sample}.genome.fastq.gz -u $R2primerlen -
+    cutadapt -j $NSLOTS -Z -o $TMPDIR/${sample}.genome.fastq.gz -u $R2primerlen ${cutadaptR2args} -
 
     # Single-end mapping using bwa aln
     bwaAlnOpts="-n ${permittedMismatches} -l 32 ${userAlnOptions} -t ${NSLOTS} -Y"
@@ -110,12 +114,12 @@ else
     echo "Adaptive trimming of R1"
     zcat -f $f1 |
     awk -v firstline=$firstline -v lastline=$lastline 'NR>=firstline && NR<=lastline' |
-    cutadapt -Z -j $NSLOTS -o $TMPDIR/${sample}.R1.fastq.gz -u ${R1primerlen} -a ${R2PrimerSeq} -g X${altDpnSeq} -
+    cutadapt -Z -j $NSLOTS -o $TMPDIR/${sample}.R1.fastq.gz -u ${R1primerlen} -a ${R2PrimerSeq} -g X${altDpnSeq} ${cutadaptR1args} -
     
     echo "Trimming $R2primerlen bp primer from R2"
     zcat -f $f2 | 
     awk -v firstline=$firstline -v lastline=$lastline 'NR>=firstline && NR<=lastline' |
-    cutadapt -Z -j $NSLOTS -u 18 -a ${firstDpnRevSeq} -a ${altDpnRevSeq} -o $TMPDIR/${sample}.genome.fastq.gz -
+    cutadapt -Z -j $NSLOTS -u 18 -a ${firstDpnRevSeq} -a ${altDpnRevSeq} ${cutadaptR2args} -o $TMPDIR/${sample}.genome.fastq.gz -
     
     bwaMemOptions="-Y -K 100000000"
     extractcmd="mem ${bwaMemOptions} -t ${NSLOTS} -R @RG\\tID:${sample}\\tLB:$DS\\tSM:${DS_nosuffix} ${bwaIndex} $TMPDIR/${sample}.R1.fastq.gz $TMPDIR/${sample}.genome.fastq.gz"

--- a/transposon/mapIntegrations.sh
+++ b/transposon/mapIntegrations.sh
@@ -117,6 +117,7 @@ else
     cutadapt -j $NSLOTS  -u ${R1primerlen} -a ${R2PrimerSeq} -g X${altDpnSeq} - -Z -o $TMPDIR/${sample}.R1.fastq.gz
     
     
+    echo
     echo "Trimming alternate Dpn site on R2"
     # R2 read adapters
     cutadapt -j $NSLOTS -a ${firstDpnRevSeq} -a ${altDpnRevSeq} $TMPDIR/${sample}.genome.fastq.gz -Z -o $TMPDIR/${sample}.genome.fastq.gz.new && mv $TMPDIR/${sample}.genome.fastq.gz.new $TMPDIR/${sample}.genome.fastq.gz

--- a/transposon/submitMerge.sh
+++ b/transposon/submitMerge.sh
@@ -57,10 +57,7 @@ if [ ${runMerge} -eq 1 ]; then
     echo "Merging barcodes from files: ${bcfiles}"
     date
     
-    if [[ ${bclen} -gt 0 ]]; then
-        zcat -f ${bcfiles} | pigz -p ${NSLOTS} -c -9 > ${OUTDIR}/${sample}.barcodes.preFilter.txt.gz
-    fi
-    
+    zcat -f ${bcfiles} | pigz -p ${NSLOTS} -c -9 > ${OUTDIR}/${sample}.barcodes.preFilter.txt.gz
     if [[ ${sampleType} == "iPCR" ]]; then
         echo "Merging bam files"
         date
@@ -89,10 +86,7 @@ fi
 cat <<EOF | qsub -S /bin/bash -j y -b y -N ${sample} -terse ${analysisHold} | perl -pe 's/[^\d].+$//g;'  #> sgeid.analysis
 set -eu -o pipefail
 
-if [[ ${bclen} -gt 0 ]]; then
-    ${src}/analyzeBCcounts.sh ${minReadCutoff} ${sample}
-fi
-
+${src}/analyzeBCcounts.sh ${minReadCutoff} ${sample}
 if [[ ${sampleType} == "iPCR" ]]; then
     ${src}/analyzeIntegrations.sh ${sample}
 fi


### PR DESCRIPTION
Included 3 configurable parameters (`minLengthForPEmapping`,  `cutadaptR1args`, `cutadaptR2args`) to adapt mapIntegrations when necessary.