### PR TITLE
Output clone transfection

### DIFF
--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -442,9 +442,10 @@ def writeOutputFiles(G, clones, output, outputlong, outputwide, cloneobj, graphO
             bcs = clone['bcs']
             cells = clone['cells']
             # Gather BC's transfection assignment set when transfectionKey is defined, otherwise defaults to None.
-            # This approach to gather BCs' transfection makes the procedure compatible with clone composed of BCs from a single or multiple transfections.
+            # If --removeConflictingCells and --removeConflictingBCs are specified, then there will be a single transfection per clone
             transfection = set()
             if transfectionKey is not None:
+                #Only record unique transfections, not any other labels
                 skip = set(["conflicting", "uninformative", "None"])
                 transfection = set(G.nodes[bc][transfectionKey] for bc in bcs if G.nodes[bc][transfectionKey] not in skip)
             if len(transfection) == 0:

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -441,10 +441,12 @@ def writeOutputFiles(G, clones, output, outputlong, outputwide, cloneobj, graphO
             umi_count = clone['umi_count']
             bcs = clone['bcs']
             cells = clone['cells']
-            transfection = set("None")
+            transfection = set()
             if transfectionKey is not None:
                 skip = set(["conflicting", "uninformative", "None"])
                 transfection = set(G.nodes[bc][transfectionKey] for bc in bcs if G.nodes[bc][transfectionKey] not in skip)
+            if len(transfection) == 0:
+                transfection.add("None")
             
             if graphOutput:
                 printGraph(subG, filename=graphOutput + '/' + clonename, edge_color='weight', **printGraph_kwds)
@@ -452,7 +454,10 @@ def writeOutputFiles(G, clones, output, outputlong, outputwide, cloneobj, graphO
             widewr.writerow({ 'BCs': ",".join(bcs), 'cellBCs': ",".join(cells), 'clone': clonename, 'count': umi_count, 'nedges': len(subG.edges), 'nBCs': len(bcs), 'ncells': len(cells), 'transfection': ",".join(transfection) })
             
             for bc in bcs:
-                longwr.writerow({ 'BC': bc, 'BCTransfection': G.nodes[bc][transfectionKey], 'clone': clonename, 'transfection': ",".join(transfection), 'count': sum([subG.edges[x]['weight'] for x in subG.edges([bc])]), 'nCells': len(subG.edges([bc]))})
+                bc_transfection = "None"
+                if transfectionKey is not None:
+                    bc_transfection = G.nodes[bc][transfectionKey]
+                longwr.writerow({ 'BC': bc, 'BCTransfection': bc_transfection, 'clone': clonename, 'transfection': ",".join(transfection), 'count': sum([subG.edges[x]['weight'] for x in subG.edges([bc])]), 'nCells': len(subG.edges([bc]))})
                 
                 #Get all neighbors for this BC (which must be cellBCs)
                 for cellBC in subG[bc]:

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -418,7 +418,7 @@ def writeOutputFiles(G, clones, output, outputlong, outputwide, cloneobj, graphO
     try:
         #Prepare file IO
         longoutfile = open(outputlong, 'w')
-        longwr = csv.DictWriter(longoutfile, delimiter='\t', lineterminator=os.linesep, skipinitialspace=True, fieldnames=['BC', 'BCTransfection', 'clone', 'transfection', 'count', 'nCells'])
+        longwr = csv.DictWriter(longoutfile, delimiter='\t', lineterminator=os.linesep, skipinitialspace=True, fieldnames=['BC', 'BC_transfection', 'clone', 'transfection', 'count', 'nCells'])
         longwr.writeheader()
             
         outputfilename = output
@@ -457,7 +457,7 @@ def writeOutputFiles(G, clones, output, outputlong, outputwide, cloneobj, graphO
                 bc_transfection = "None"
                 if transfectionKey is not None:
                     bc_transfection = G.nodes[bc][transfectionKey]
-                longwr.writerow({ 'BC': bc, 'BCTransfection': bc_transfection, 'clone': clonename, 'transfection': ",".join(transfection), 'count': sum([subG.edges[x]['weight'] for x in subG.edges([bc])]), 'nCells': len(subG.edges([bc]))})
+                longwr.writerow({ 'BC': bc, 'BC_transfection': bc_transfection, 'clone': clonename, 'transfection': ",".join(transfection), 'count': sum([subG.edges[x]['weight'] for x in subG.edges([bc])]), 'nCells': len(subG.edges([bc]))})
                 
                 #Get all neighbors for this BC (which must be cellBCs)
                 for cellBC in subG[bc]:

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -418,7 +418,7 @@ def writeOutputFiles(G, clones, output, outputlong, outputwide, cloneobj, graphO
     try:
         #Prepare file IO
         longoutfile = open(outputlong, 'w')
-        longwr = csv.DictWriter(longoutfile, delimiter='\t', lineterminator=os.linesep, skipinitialspace=True, fieldnames=['BC', 'clone', 'count', 'nCells'])
+        longwr = csv.DictWriter(longoutfile, delimiter='\t', lineterminator=os.linesep, skipinitialspace=True, fieldnames=['BC', 'BCTransfection', 'clone', 'transfection', 'count', 'nCells'])
         longwr.writeheader()
             
         outputfilename = output
@@ -452,7 +452,7 @@ def writeOutputFiles(G, clones, output, outputlong, outputwide, cloneobj, graphO
             widewr.writerow({ 'BCs': ",".join(bcs), 'cellBCs': ",".join(cells), 'clone': clonename, 'count': umi_count, 'nedges': len(subG.edges), 'nBCs': len(bcs), 'ncells': len(cells), 'transfection': ",".join(transfection) })
             
             for bc in bcs:
-                longwr.writerow({ 'BC': bc, 'clone': clonename, 'count': sum([subG.edges[x]['weight'] for x in subG.edges([bc])]), 'nCells': len(subG.edges([bc]))})
+                longwr.writerow({ 'BC': bc, 'BCTransfection': G.nodes[bc][transfectionKey], 'clone': clonename, 'transfection': ",".join(transfection), 'count': sum([subG.edges[x]['weight'] for x in subG.edges([bc])]), 'nCells': len(subG.edges([bc]))})
                 
                 #Get all neighbors for this BC (which must be cellBCs)
                 for cellBC in subG[bc]:

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -441,6 +441,8 @@ def writeOutputFiles(G, clones, output, outputlong, outputwide, cloneobj, graphO
             umi_count = clone['umi_count']
             bcs = clone['bcs']
             cells = clone['cells']
+            # Gather BC's transfection assignment set when transfectionKey is defined, otherwise defaults to None.
+            # This approach to gather BCs' transfection makes the procedure compatible with clone composed of BCs from a single or multiple transfections.
             transfection = set()
             if transfectionKey is not None:
                 skip = set(["conflicting", "uninformative", "None"])
@@ -454,6 +456,7 @@ def writeOutputFiles(G, clones, output, outputlong, outputwide, cloneobj, graphO
             widewr.writerow({ 'BCs': ",".join(bcs), 'cellBCs': ",".join(cells), 'clone': clonename, 'count': umi_count, 'nedges': len(subG.edges), 'nBCs': len(bcs), 'ncells': len(cells), 'transfection': ",".join(transfection) })
             
             for bc in bcs:
+                # Default BC_Transfection to None when transfectionKey is not defined
                 bc_transfection = "None"
                 if transfectionKey is not None:
                     bc_transfection = G.nodes[bc][transfectionKey]


### PR DESCRIPTION
This PR aims to extend `genotypeClones.py` output to include the BC and Clone transfections assigned when available. It changes the `.clones.txt` file to a table with the following columns:

- BCs
- cellBCs
- clone
- **transfection** (new column included here)
- count
- nedges
- nBCs
- ncells

and changes `.clones.counts.filtered.txt` file to a table with the following columns:

- BC
- **BCTransfection**  (new column included here)
- clone
- **transfection**  (new column included here)
- count
- nCells