### PR TITLE
genotypeClones improvement

### DIFF
--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -258,8 +258,13 @@ def breakUpWeaklyConnectedCommunities(G, minCentrality, maxPropReads, doGraph=Fa
         nodesToPrune = set()
         if len(bcs) > 0 and len(cells) > 0:
             precloneid += 1
+            mkdir -p $outdir
+
+            #Identify bridges and sort nodes to ensure consistency
+            bridges = [tuple(sorted(e)) for e in nx.bridges(subG)]
             #Start with edges with lowest UMIs
-            for edge in sorted(nx.bridges(subG), key=lambda e: subG.edges[e]['weight'], reverse=False):
+            #include edge vertices to sort key, to ensure consistent order
+            for edge in sorted(bridges, key=lambda e: (subG.edges[e]['weight'], e[0], e[1]), reverse=False):
                 subGedgeless = subG.copy()
                 subGedgeless.remove_edge(edge[0], edge[1])
                 leftNodes = nx.algorithms.components.node_connected_component(subGedgeless, edge[0])

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -263,10 +263,13 @@ def breakUpWeaklyConnectedCommunities(G, minCentrality, maxPropReads, doGraph=Fa
             #Identify bridges and sort nodes to ensure consistency
             bridges = [tuple(sorted(e)) for e in nx.bridges(subG)]
             #Start with edges with lowest UMIs
-            #include edge vertices to sort key, to ensure consistent order
+            #Include edge vertices to sort key, to ensure consistent order
             for edge in sorted(bridges, key=lambda e: (subG.edges[e]['weight'], e[0], e[1]), reverse=False):
-                subGedgeless = subG.copy()
-                subGedgeless.remove_edge(edge[0], edge[1])
+                #Skip border bridges where either nodes are connected to none other
+                if subG.degree[edge[0]] == 1 or subG.degree[edge[1]] == 1:
+                    continue
+                #Produce a view of subG, hiding the bridge edge
+                subGedgeless = nx.restricted_view(subG, [], [edge])
                 leftNodes = nx.algorithms.components.node_connected_component(subGedgeless, edge[0])
                 rightNodes = nx.algorithms.components.node_connected_component(subGedgeless, edge[1])
                 

--- a/transposon/genotypeClones.py
+++ b/transposon/genotypeClones.py
@@ -258,8 +258,6 @@ def breakUpWeaklyConnectedCommunities(G, minCentrality, maxPropReads, doGraph=Fa
         nodesToPrune = set()
         if len(bcs) > 0 and len(cells) > 0:
             precloneid += 1
-            mkdir -p $outdir
-
             #Identify bridges and sort nodes to ensure consistency
             bridges = [tuple(sorted(e)) for e in nx.bridges(subG)]
             #Start with edges with lowest UMIs


### PR DESCRIPTION
This PR includes:
- a consistency fix to make the results of `genotypeClones.py` consistent between multiple runs.
  - When executed multiple times, the code produced slightly different results due to bridges ordering, which was random between bridges of the same `weight`. To ensure consistent behaviour, I ordered edge vertices and when sorting bridges, also sorted them by the vertices.
- two small code optimizations to improve processing time.
  - Added a quick skip of border bridges, linking a component to a node without any other connection.
  - Replace `subG.copy`, by `nx.restricted_view(subG, [], [edge])` which produce a view of the graph hiding the bridge edge. This avoids the heavy step of cloning `subG` and significantly reduced processing time
