### PR TITLE
MakeTrackhub.py compatible with updated trackhub

### DIFF
--- a/dnase/trackhub/MakeTrackhub.py
+++ b/dnase/trackhub/MakeTrackhub.py
@@ -11,7 +11,9 @@ import locale
 import csv
 import os
 import urllib.parse
-
+## Suppress shortName user warnings
+import warnings
+warnings.filterwarnings("ignore", category=UserWarning, module=trackhub.get("__name__"))
 
 locale.setlocale(locale.LC_ALL, 'en_US')
 

--- a/dnase/trackhub/MakeTrackhub.py
+++ b/dnase/trackhub/MakeTrackhub.py
@@ -236,7 +236,7 @@ for assay_type in assays:
             long_label=lng_label,
             tracktype="bigBed",
             visibility="hide",
-            parentonoff="off",
+            parent="off",
             sortOrder=SortOrder,
             autoScale = "off",
             bigDataUrl ='NULL',
@@ -376,7 +376,7 @@ for assay_type in assays:
                     name="Reads_view_" + curGroup_trackname,
                     view="Reads",
                     visibility="hide",
-                    parentonoff="off",
+                    parent="off",
                     tracktype="bam",
                     short_label="Reads",
                     maxItems=50000, #Set high so that dense sequencing tracks can be displayed as this parameter can not be changed in the UI
@@ -392,7 +392,7 @@ for assay_type in assays:
                 url=args.URLbase + urllib.parse.quote(curSample['filebase']) + '.bam',
                 subgroups=sampleSubgroups,
                 tracktype='bam',
-                parentonoff="off"
+                parent="off"
             )
             Reads_view.add_tracks(track)
             
@@ -404,7 +404,7 @@ for assay_type in assays:
                             name="Coverage_view_" + curGroup_trackname,
                             view="Coverage",
                             visibility="full",
-                            parentonoff=DensCovTracksDefaultDisplayMode,
+                            parent=DensCovTracksDefaultDisplayMode,
                             tracktype="bigWig",
                             viewLimits="0:500", #Keep high since it becomes a hard limit in the UI
                             autoScale='on',
@@ -422,7 +422,7 @@ for assay_type in assays:
                         subgroups=sampleSubgroups,
                         tracktype='bigWig',
                         color=curSample['Color'],
-                        parentonoff=DensCovTracksDefaultDisplayMode
+                        parent=DensCovTracksDefaultDisplayMode
                     )
                     Coverage_view.add_tracks(track)
                 
@@ -433,7 +433,7 @@ for assay_type in assays:
                             name="Dens_view_" + curGroup_trackname,
                             view="Density",
                             visibility="full",
-                            parentonoff=DensCovTracksDefaultDisplayMode,
+                            parent=DensCovTracksDefaultDisplayMode,
                             tracktype="bigWig",
                             viewLimits="0:3",
                             autoScale="off",
@@ -450,7 +450,7 @@ for assay_type in assays:
                         subgroups=sampleSubgroups, 
                         tracktype='bigWig',
                         color=curSample['Color'],
-                        parentonoff="off" if assay_type=='ChIP-seq' and curSample['Assay']=='input' else DensCovTracksDefaultDisplayMode
+                        parent="off" if assay_type=='ChIP-seq' and curSample['Assay']=='input' else DensCovTracksDefaultDisplayMode
                     )
                     Dens_view.add_tracks(track)
                 
@@ -465,7 +465,7 @@ for assay_type in assays:
                             name="Hotspots_view_" + curGroup_trackname,
                             view="Hotspots",
                             visibility="hide",
-                            parentonoff="off",
+                            parent="off",
                             tracktype="bigBed",
                             maxItems=250,
                             short_label="Hotspots",
@@ -479,7 +479,7 @@ for assay_type in assays:
                         subgroups=sampleSubgroups,
                         tracktype='bigBed 4',
                         color=curSample['Color'],
-                        parentonoff="off"
+                        parent="off"
                     )
                     Hotspots_view.add_tracks(track)
                     
@@ -489,7 +489,7 @@ for assay_type in assays:
                             name="Peaks_view_" + curGroup_trackname,
                             view="Peaks",
                             visibility="hide",
-                            parentonoff="off",
+                            parent="off",
                             tracktype="bigBed",
                             maxItems=250,
                             short_label="Peaks",
@@ -503,7 +503,7 @@ for assay_type in assays:
                         subgroups=sampleSubgroups,
                         tracktype='bigBed 3',
                         color=curSample['Color'],
-                        parentonoff="off"
+                        parent="off"
                     )
                     Peaks_view.add_tracks(track)
                 
@@ -514,7 +514,7 @@ for assay_type in assays:
                             name="Cuts_view_" + curGroup_trackname,
                             view="Cuts",
                             visibility="hide",
-                            parentonoff="off",
+                            parent="off",
                             tracktype="bigWig",
                             viewLimits="0:2",
                             autoScale="off",
@@ -531,7 +531,7 @@ for assay_type in assays:
                         subgroups=sampleSubgroups,
                         tracktype='bigWig',
                         color=curSample['Color'],
-                        parentonoff="off"
+                        parent="off"
                     )
                     Cuts_view.add_tracks(track)
                 
@@ -542,7 +542,7 @@ for assay_type in assays:
                             name="Variants_view_" + curGroup_trackname,
                             view="Variants",
                             visibility="hide",
-                            parentonoff="off",
+                            parent="off",
                             tracktype='vcfTabix',
                             maxItems=250,
                             applyMinQual="true",
@@ -557,7 +557,7 @@ for assay_type in assays:
                         url=args.URLbase + urllib.parse.quote(curSample['filebase']) + '.filtered.vcf.gz',
                         subgroups=sampleSubgroups,
                         tracktype='vcfTabix',
-                        parentonoff="off"
+                        parent="off"
                     )
                     Variants_view.add_tracks(track)
                 
@@ -568,7 +568,7 @@ for assay_type in assays:
                             name="Genotypes_view_" + curGroup_trackname,
                             view="Genotypes",
                             visibility="dense",
-                            parentonoff="off",
+                            parent="off",
                             tracktype="bigBed",
                             maxItems=100000,
                             short_label="Genotypes",
@@ -583,7 +583,7 @@ for assay_type in assays:
                         tracktype='bigBed 9 .',
                         color=curSample['Color'],
                         itemRgb="on",
-                        parentonoff="off"
+                        parent="off"
                     )
                     Genotypes_view.add_tracks(track)
                 
@@ -594,7 +594,7 @@ for assay_type in assays:
                             name="Delly_view_" + curGroup_trackname,
                             view="DELLY",
                             visibility="pack",
-                            parentonoff="off",
+                            parent="off",
                             tracktype='vcfTabix',
                             maxItems=250,
                             applyMinQual="true",
@@ -609,7 +609,7 @@ for assay_type in assays:
                         url=args.URLbase + urllib.parse.quote(curSample['filebase']) + '.DELLY.filtered.vcf.gz',
                         subgroups=sampleSubgroups,
                         tracktype='vcfTabix',
-                        parentonoff="off"
+                        parent="off"
                     )
                     Delly_view.add_tracks(track)
         

--- a/dnase/trackhub/MakeTrackhub.py
+++ b/dnase/trackhub/MakeTrackhub.py
@@ -12,9 +12,8 @@ import csv
 import os
 import urllib.parse
 ## Suppress shortName user warnings
-import trackhub
 import warnings
-warnings.filterwarnings("ignore", category=UserWarning, module=trackhub.get("__name__"))
+warnings.filterwarnings("ignore", category=UserWarning)
 
 locale.setlocale(locale.LC_ALL, 'en_US')
 

--- a/dnase/trackhub/MakeTrackhub.py
+++ b/dnase/trackhub/MakeTrackhub.py
@@ -11,9 +11,6 @@ import locale
 import csv
 import os
 import urllib.parse
-## Suppress shortName user warnings
-import warnings
-warnings.filterwarnings("ignore", category=UserWarning)
 
 locale.setlocale(locale.LC_ALL, 'en_US')
 

--- a/dnase/trackhub/MakeTrackhub.py
+++ b/dnase/trackhub/MakeTrackhub.py
@@ -12,6 +12,7 @@ import csv
 import os
 import urllib.parse
 ## Suppress shortName user warnings
+import trackhub
 import warnings
 warnings.filterwarnings("ignore", category=UserWarning, module=trackhub.get("__name__"))
 


### PR DESCRIPTION
Fix intended to make `MakeTrackhub.py` compatible with the updated version of trackhub (`v0.2.4-mauranolab`). For such purpose, it was necessary to:
- replace all instances of `parentonoff` by `parent`