### PR TITLE
Fix/starchcat double free

### DIFF
--- a/dnase/submit.sh
+++ b/dnase/submit.sh
@@ -12,7 +12,7 @@ export OPENBLAS_NUM_THREADS=1
 module load picard/2.26.10
 module load fastqc/0.11.7
 module load bedtools/2.30.0
-module load bedops/2.4.41
+module load bedops/2.4.42
 module load bwa/0.7.17
 module load minimap2/2.28
 module load htslib/1.20

--- a/dnase/trackhub/update_tracks.bash
+++ b/dnase/trackhub/update_tracks.bash
@@ -44,7 +44,7 @@ set -eu -o pipefail
 #
 ############################################################################
 module load ucscutils/398
-module load bedops/2.4.41
+module load bedops/2.4.42
 module load r/4.4.1
 module load python/cpu/3.10.6
 module load miller/6.11.0


### PR DESCRIPTION
Fixes #275 

Changes:
Updates the modules to use the latest version of bedops (2.4.42)

Why:
The previous version of bedops (2.4.41) had a bug in the starchcat script that would result in a double-free error in particular circumstances. This would cause the pipeline to fail as the analysis job would fail with an error.

Testing:
I reran the pipeline on the sample that had the error and checked that it completed successfully.