### PR TITLE
make samplesforTrackhub more performant

### DIFF
--- a/dnase/trackhub/samplesforTrackhub.R
+++ b/dnase/trackhub/samplesforTrackhub.R
@@ -181,8 +181,11 @@ if(opt$project == "CEGS_byLocus") {
     outputCols <- c(outputCols, "Study", "Project", "Assembly", "Type")
 }
 
-#Fill the data table with "NA" values so that missing values are NA in the final output
-data <- data.table(matrix("NA", ncol=length(outputCols), nrow=analysis_file_count))
+#Fill the data table with NA values so that missing values are NA in the final output
+data <- data.table(matrix(NA, ncol=length(outputCols), nrow=analysis_file_count))
+# Initializing the values as NA makes the columns default to logical type
+# This converts the columns to character type, but maintains the NA values
+data <- data[, lapply(.SD, as.character), .SDcols = names(data)]
 colnames(data) <- outputCols
 i <- 0L # This will be our "data" output variable index.
 for(curdir in mappeddirs) {
@@ -340,7 +343,7 @@ for(curdir in mappeddirs) {
 			} else if(opt$project=="CEGS_byLocus") {
 				#Group values will be in the form of Study ID
 				
-				if(data$Genetic_Modification[i] == "NA") {
+				if(is.na(data$Genetic_Modification[i])) {
 					#Based on sample name
 					SampleNameSplit <- unlist(strsplit(data$Name[i], "_"))
 					CEGSsampleType <- SampleNameSplit[length(SampleNameSplit)]
@@ -407,12 +410,12 @@ for(curdir in mappeddirs) {
 				}
 				
 				#Collect Duke samples and remaining UW samples into groups
-				if(data$Group[i] == "NA" || data$Institution[i] == "Duke") {
+				if(is.na(data$Group[i]) || data$Institution[i] == "Duke") {
 					set(data, i, "Group", data$Institution[i])
 				}
 			} else if(opt$project %in% c("mouseENCODEdnase", "mouseENCODEchipseq", "humanENCODEchipseq")) {
 				if(opt$project =="humanENCODEchipseq" && data$Name[i]=="GM12878") { data$Group[i] <- "Tier_1" }
-				if(data$Group[i] == "NA") {
+				if(is.na(data$Group[i])) {
 					set(data, i, "Group", "Cell lines")
 					if(opt$project =="humanENCODEchipseq") {
 						if(data$Name[i] %in% c("K562", "GM12878")) {
@@ -495,7 +498,7 @@ if(opt$project %in% c("humanENCODEdnase", "mouseENCODEdnase", "humanENCODEchipse
 
 if(opt$project=="CEGS_byLocus") {
 	# Delete line items not associated with one of the enumerated "CEGSsampleType" sample types.
-	data <- data[!data$Group == "NA",]
+	data <- data[!is.na(data$Group),]
 }
 
 #Output file:

--- a/dnase/trackhub/samplesforTrackhub.R
+++ b/dnase/trackhub/samplesforTrackhub.R
@@ -317,7 +317,8 @@ for(curdir in mappeddirs) {
 			#Note that color has already been established and won't be redone if sample name changes
 			
 			#Matching the DS number from the analysis file to inputSampleIDs can give multiple results, so just pick the first
-			inputSampleIDrow <- which(inputSampleIDs[,"DS"] == data[i, "SampleID"])[1]
+			# data.table[x, y] returns a list and needs to be indexed to extract the value
+			inputSampleIDrow <- which(inputSampleIDs[,"DS"] == data[i, "SampleID"][[1]])[1]
 			
 			#Take all columns to be taken from inputSampleIDs
 			for(curCol in intersect(outputCols, setdiff(colnames(inputSampleIDs), "DS"))) {

--- a/dnase/trackhub/samplesforTrackhub.R
+++ b/dnase/trackhub/samplesforTrackhub.R
@@ -165,6 +165,15 @@ colorPalette <- sapply(colorPalette, FUN=function(x) { paste(col2rgb(x), collaps
 nextColorFromPalette <- 0
 colorAssignments <- NULL
 
+#Count the number of analysis files to initialize the output data table
+analysis_file_count <- 0
+for(curdir in mappeddirs) {
+  analysisFiles <- list.files(path=paste0(pwd, '/', curdir), pattern="^(makeTracks|analysis).*")
+  analysis_file_count <- analysis_file_count + length(analysisFiles)
+}
+
+message("[samplesforTrackhub] ", "Analysis file count: ", analysis_file_count)
+
 
 # Initialize "data" with just column names.  We'll be adding rows to this later on in the code.
 outputCols <- c("Name", "SampleID", "Assay", "Group", "filebase", "Mapped_Genome", "Annotation_Genome", "Color", "analyzed_reads", "Genomic_coverage", "SPOT", "Num_hotspots", "Exclude", "Age", "Institution", "Replicate", "Bait_set", "Genetic_Modification")
@@ -172,9 +181,10 @@ if(opt$project == "CEGS_byLocus") {
     outputCols <- c(outputCols, "Study", "Project", "Assembly", "Type")
 }
 
-data <- data.frame(matrix(ncol=length(outputCols), nrow=1))
+#Fill the data table with "NA" values so that missing values are NA in the final output
+data <- data.table(matrix("NA", ncol=length(outputCols), nrow=analysis_file_count))
 colnames(data) <- outputCols
-i <- 0 # This will be our "data" output variable index.
+i <- 0L # This will be our "data" output variable index.
 for(curdir in mappeddirs) {
 	if(!"quiet" %in% names(opt)) {
 		message("[samplesforTrackhub] ", curdir)
@@ -207,9 +217,7 @@ for(curdir in mappeddirs) {
 		if(tail(analysisFileContents, 2)[1] != "Done!"){
 			message("[samplesforTrackhub] ", "WARNING ", analysisFile, " appears not to have completed successfully")
 		}
-		i <- i+1
-		# We need to add a new row to "data". The values will be set within this for loop.
-		data[i,] <- NA
+		i <- i+1L
 		
 		pipelineParameters <- analysisFileContents[grep('^Running [^,]+,[^,]+ analysis', analysisFileContents, perl=T)]
 		if(length(pipelineParameters)>0) {
@@ -217,16 +225,16 @@ for(curdir in mappeddirs) {
 			mappedgenome <- pipelineParametersParser(pipelineParameters, "mappedgenome")
 			annotationgenome <- pipelineParametersParser(pipelineParameters, "annotationgenome")
 			
-			data$Mapped_Genome[i] <- mappedgenome
+			set(data, i, "Mapped_Genome", mappedgenome)
 			
 			# Is the annotation geneome in the "Running ... analysis ..." line ?
 			if(nchar(annotationgenome) > 0) {
 				# It is.
-				data$Annotation_Genome[i] <- annotationgenome
+				set(data, i, "Annotation_Genome", annotationgenome)
 			} else {
 				# It is not. Extract it from the "mappedgenome" field.
 				annotationgenome <- gsub("_.+$", "", mappedgenome)
-				data$Annotation_Genome[i] <- gsub("all$", "", annotationgenome)
+				set(data, i, "Annotation_Genome", gsub("all$", "", annotationgenome))
 			}
 		} else {
 			#assume dnase for old pipeline
@@ -236,36 +244,36 @@ for(curdir in mappeddirs) {
 		# Adding a new Assay type also requires changes to be made to MakeTrackhub.py
 		# Look for the initialization of "assay_type" in MakeTrackhub.py for comments on this.
 		if(sampleType=="dnase") {
-			data$Assay[i] <- "DNase-seq"
+			set(data, i, "Assay", "DNase-seq")
 		} else if(sampleType=="atac") {
-			data$Assay[i] <- "ATAC-seq"
+			set(data, i, "Assay", "ATAC-seq")
 		} else if(sampleType=="none") {
-			data$Assay[i] <- "None"
+			set(data, i, "Assay", "None")
 		} else if(sampleType=="dna" || sampleType=="callsnps") {
-			data$Assay[i] <- "DNA"
+			set(data, i, "Assay", "DNA")
 		} else if(sampleType=="capture" || sampleType=="callsnpsCapture") {
-			data$Assay[i] <- "DNA Capture"
+			set(data, i, "Assay", "DNA Capture")
 		} else if(sampleType=="amplicon") {
-			data$Assay[i] <- "Amplicon"
+			set(data, i, "Assay", "Amplicon")
 		} else if(sampleType=="chipseq") {
-			data$Assay[i] <- SampleIDsplit[2]
+			set(data, i, "Assay", SampleIDsplit[2])
 		} else {
 			message("[samplesforTrackhub] ", "WARNING don't recognize sampleType: ", sampleType)
 		}
 		
-		data$Name[i] <- SampleIDsplit[1]
+		set(data, i, "Name", SampleIDsplit[1])
 		
-		data[i, "SampleID"] <- SampleIDsplit[length(SampleIDsplit)]
+		set(data, i, "SampleID", SampleIDsplit[length(SampleIDsplit)])
 		
 		#TODO parameterize setting a different key for color lookup
 		if(is.null(colorAssignments) || !data$Name[i] %in% colorAssignments$group) {
 			colorAssignments <- rbind(colorAssignments, data.frame(group=data$Name[i], rgb=colorPalette[nextColorFromPalette+1], stringsAsFactors=F))
 			nextColorFromPalette <- (nextColorFromPalette + 1) %% length(colorPalette)
 		}
-		data$Color[i] <- colorAssignments[colorAssignments$group == data$Name[i], "rgb"]
+		set(data, i, "Color", colorAssignments[colorAssignments$group == data$Name[i], "rgb"])
 		
 		if(any(grepl('^Num_analyzed_(tags|reads)\t', analysisFileContents))) {
-			data$analyzed_reads[i] <- strsplit(analysisFileContents[grep('^Num_analyzed_(tags|reads)\t', analysisFileContents)], '\t')[[1]][2] #Tags is for old pipeline
+			set(data, i, "analyzed_reads", strsplit(analysisFileContents[grep('^Num_analyzed_(tags|reads)\t', analysisFileContents)], '\t')[[1]][2]) #Tags is for old pipeline
 		}
 		
 		#Parse SampleAnnotation as a list of values with the key as name
@@ -286,23 +294,23 @@ for(curdir in mappeddirs) {
 		}
 		
 		if( !is.null(SampleAnnotation[["Bait_set"]]) ) {
-			data$Bait_set[i] <- SampleAnnotation[["Bait_set"]]
+			set(data, i, "Bait_set", SampleAnnotation[["Bait_set"]])
 		}
 		
 		if( !is.null(SampleAnnotation[["Genetic_Modification"]]) ) {
-			data$Genetic_Modification[i] <- SampleAnnotation[["Genetic_Modification"]]
+			set(data, i, "Genetic_Modification", SampleAnnotation[["Genetic_Modification"]])
 		}
 		
 		if(any(grepl('^Genomic_coverage\t', analysisFileContents))) {
-			data$Genomic_coverage[i] <- strsplit(analysisFileContents[grep('^Genomic_coverage\t', analysisFileContents)], '\t')[[1]][2]
+			set(data, i, "Genomic_coverage", strsplit(analysisFileContents[grep('^Genomic_coverage\t', analysisFileContents)], '\t')[[1]][2])
 		}
 		
 		if(any(grepl('^Num_hotspots2\t', analysisFileContents))) {
-			data$Num_hotspots[i] <- strsplit(analysisFileContents[grep('^Num_hotspots2\t', analysisFileContents)], '\t')[[1]][2]
+			set(data, i, "Num_hotspots", strsplit(analysisFileContents[grep('^Num_hotspots2\t', analysisFileContents)], '\t')[[1]][2])
 		}
 		
 		if(any(grepl('^SPOT\t', analysisFileContents))) {
-			data$SPOT[i] <- strsplit(analysisFileContents[grep('^SPOT\t', analysisFileContents)], '\t')[[1]][2]
+			set(data, i, "SPOT", strsplit(analysisFileContents[grep('^SPOT\t', analysisFileContents)], '\t')[[1]][2])
 		}
 		
 		if(!is.null(inputSampleIDs)) {
@@ -314,25 +322,25 @@ for(curdir in mappeddirs) {
 			#Take all columns to be taken from inputSampleIDs
 			for(curCol in intersect(outputCols, setdiff(colnames(inputSampleIDs), "DS"))) {
 				if(!is.na(inputSampleIDs[inputSampleIDrow, curCol])) {
-					data[i, curCol] <- inputSampleIDs[inputSampleIDrow, curCol]
+					set(data, i, curCol, inputSampleIDs[inputSampleIDrow, curCol])
 				}
 			}
 		}
 		
 		if(opt$project %in% c("byFC", "CEGS_byLocus")) {
-			data$Institution[i] <- "NYU"
+			set(data, i, "Institution", "NYU")
 			
 			if(opt$project=="byFC") {
 				curFC <- unlist(strsplit(curdir, "/"))[1]
-				data$Group[i] <- curFC
+				set(data, i, "Group", curFC)
 				if(curFC %in% names(flowcell_dates)) {
 					#Group values will be in the form of YYYMMDD_<flowcell>
-					data$Group[i] <- paste0(flowcell_dates[[curFC]] , "_" , data$Group[i])
+					set(data, i, "Group", paste0(flowcell_dates[[curFC]] , "_" , data$Group[i]))
 				}
 			} else if(opt$project=="CEGS_byLocus") {
 				#Group values will be in the form of Study ID
 				
-				if(is.na(data$Genetic_Modification[i])) {
+				if(data$Genetic_Modification[i] == "NA") {
 					#Based on sample name
 					SampleNameSplit <- unlist(strsplit(data$Name[i], "_"))
 					CEGSsampleType <- SampleNameSplit[length(SampleNameSplit)]
@@ -368,75 +376,84 @@ for(curdir in mappeddirs) {
 				}
 				
 				if(CEGSsampleType %in% c("Yeast", "DNA", "BAC", "RepoBAC", "Ecoli", "Amplicon", "PayloadCells", "LP_Cells")) {
-					data$Study[i] <- SampleNameSplit[1]
+					set(data, i, "Study", SampleNameSplit[1])
 					if(CEGSsampleType != "RepoBAC") {
 						#RepoBAC just have a SampleID field which doesn't make it into a specific UCSC field right now
-						data$Project[i] <- SampleNameSplit[2]
-						data$Assembly[i] <- SampleNameSplit[3]
+						set(data, i, "Project", SampleNameSplit[2])
+						set(data, i, "Assembly", SampleNameSplit[3])
 						if(length(SampleNameSplit) >= 4) {
 							#The 4th field in Genetic Modification can specify an alternate backbone
-							data$Info[i] <- SampleNameSplit[4]
+							set(data, i, "Info", SampleNameSplit[4])
 						}
 					}
-					data$Type[i] <- CEGSsampleType
-					data$Group[i] <- data$Study[i]
+					set(data, i, "Type", CEGSsampleType)
+					set(data, i, "Group", data$Study[i])
 				}
 			} else {
 				stop("ERROR Impossible!")
 			}
 		} else if(opt$project %in% c("humanENCODEdnase", "mouseENCODEdnase", "humanENCODEchipseq", "mouseENCODEchipseq")) {
 			if(grepl('^f[A-Z]|^mfLiver_', data$Name[i])) {
-				data$Group[i] <- "Fetal tissues"
+				set(data, i, "Group", "Fetal tissues")
 			} else if(grepl('^(adipo|aggregated_lymphoid_nodule|adrenal|ammon|aorta|artery|astrocyte|bladder|body|bone|bowel|brain|breast|bronchial_epithelial_cell|cardia|cardiocyte|cerebellum|colon|coronary_artery|cortex|cortical_plate|dendritic_cell|derm|epithelial_cell_of_choroid_plexus|erythroblast|esopha|eye|fetal_umbilical_cord|fibroblast|gast|gastro|globus|glom|gonad|gyrus|heart|hepatocyte|intest|keratinocyte|kidney|limb|liver|lung|mammary_epithelial_cell|medial_popliteal_nerve|medull|medulla|mesenchymal_stem_cell|mid_neurogenesis_radial_glial_cells|muscle|myotube|neural_cell|neural_progenitor_cell|neural_stem_progenitor_cell|neuroepithelial_stem_cell|neuron|nucleus|oesteoblast|olfact|fat_pad|osteo|ovary|pancrea|placenta|pons|prostate|psoas|putamen|radial_glial_cell|renal|retina|retinal_pigment_epithelial_cell|right_atrium_auricular_region|right_lobe_of_liver|skin|spinal|spleen|stomach|test[ei]s|thymus|thyroid|tibial_artery|tibial_nerve|tongue|trophoblast_cell|urothelia|uteru|vagina|ventriculus|amniotic_stem_cell|bipolar_spindle_neuron|caput_mediale_musculus_gastrocnemius|inferior_parietal_cortex|islet_precursor_cell|midbrain|middle_frontal_gyrus|pentadactyl_limb|ascending_aorta|bipolar_neuron|epithelial_cell_of_esophagus|epithelial_cell_of_prostate|foreskin_keratinocyte|lower_leg_skin|Peyers_patch|right_cardiac_atrium|sigmoid_colon|skeletal_muscle|small_intestine|smooth_muscle_cell|suprapubic_skin|thoracic_aorta|transverse_colon|upper_lobe_of_left_lung|urinary_bladder|brown_adipose_tissue|forebrain|hindbrain|myocyte|Muller_cell|telencephalon|omental)', data$Name[i], ignore.case=T)) {
-				data$Group[i] <- "Tissues"
+				set(data, i, "Group", "Tissues")
 			}
 			if(grepl('^CD|^[him]?A?T[HhNnRr][0-9]*$|^GM[012][0-9][0-9][0-9][0-9]|m?B_?cell|neutrophil|natural_killer|regulatory_T_cell|^MEL$|^MEL_GATA1_ER$|macrophage|CH12LX|G1E|mononuclear|megakaryocyte|dendritic|leukemia_stem_cell|^Jurkat|T\\-cell|Raji|NB4|HL\\-60|Karpas\\-422|Loucy', data$Name[i])) { data$Group[i] <- 'Hematopoietic' }
 			if(grepl('ES|^H[179]_hESC|GM23338|^iPS|^trophoblastic_cell$|^mesendoderm$|^endodermal_cell$|^ectodermal_cell$|^mesodermal_cell$|^WW6$|^ZHBTc4$|^E14TG2a.?4$|^ELF_1$|^EL$|^L1_S8$', data$Name[i])) { data$Group[i] <- 'Pluripotent' }
 			if(opt$project=="humanENCODEdnase") {
 				#Correct UMass to UW samples
 				if(data$Institution[i] == 'UMass') {
-					data$Institution[i] <- 'UW'
+					set(data, i, "Institution", 'UW')
 				}
 				
 				#Collect Duke samples and remaining UW samples into groups
-				if(is.na(data$Group[i]) || data$Institution[i] == "Duke") {
-					data$Group[i] <- data$Institution[i]
+				if(data$Group[i] == "NA" || data$Institution[i] == "Duke") {
+					set(data, i, "Group", data$Institution[i])
 				}
 			} else if(opt$project %in% c("mouseENCODEdnase", "mouseENCODEchipseq", "humanENCODEchipseq")) {
 				if(opt$project =="humanENCODEchipseq" && data$Name[i]=="GM12878") { data$Group[i] <- "Tier_1" }
-				if(is.na(data$Group[i])) {
-					data$Group[i] <- "Cell lines"
+				if(data$Group[i] == "NA") {
+					set(data, i, "Group", "Cell lines")
 					if(opt$project =="humanENCODEchipseq") {
 						if(data$Name[i] %in% c("K562", "GM12878")) {
 							#NB H1 is tier 1 but I want to leave it in pluripotent so it is easy to find
-							data$Group[i] <- "Tier_1"
+							set(data, i, "Group", "Tier_1")
 						} else if(data$Name[i] %in% c("HepG2", "HeLa_S3", "A549", "IMR_90", "MCF_7", "SK_N_SH", "endothelial_cell_of_umbilical_vein")) {
-							data$Group[i] <- "Tier_2"
+							set(data, i, "Group", "Tier_2")
 						}
 					}
 				}
 				if(opt$project %in% c("mouseENCODEchipseq", "humanENCODEchipseq")) {
 					if(grepl("[Tt]issues$", data$Group[i]) || opt$project=="humanENCODEchipseq" && grepl("^(Cell lines|Tier_)", data$Group[i])) {
 						if(grepl('^H[234][ABFK]', data$Assay[i])) {
-							data$Group[i] <- paste0(data$Group[i], "-Histone marks")
+							set(data, i, "Group", paste0(data$Group[i], "-Histone marks"))
 						} else {
-							data$Group[i] <- paste0(data$Group[i], "-TFs")
+							set(data, i, "Group", paste0(data$Group[i], "-TFs"))
 						}
 					}
-					if(grepl('eGFP|(3x)?FLAG', data$Assay[i], ignore.case=T)) { data$Group[i] <- 'Epitope-tagged TFs' }
-					if(grepl('control', data$Assay[i], ignore.case=T)) { data$Group[i] <- 'Control' }
-					if(data$Assay[i] == "CTCF") { data$Group[i] <- 'CTCF' }
+					if(grepl('eGFP|(3x)?FLAG', data$Assay[i], ignore.case=T)) { 
+					  set(data, i, "Group", 'Epitope-tagged TFs')
+					}
+					if(grepl('control', data$Assay[i], ignore.case=T)) { 
+					  set(data, i, "Group", 'Control')
+					}
+					if(data$Assay[i] == "CTCF") { 
+					  set(data, i, "Group", 'CTCF')
+					}
 				}
 			}
 		} else {
-			data$Group[i] <- data$Institution[i]
+			set(data, i, "Group", data$Institution[i])
 		}
 		
-		data$filebase[i] <- paste0(curdir, "/", paste0(unlist(strsplit(basename(analysisFile), "\\."))[2:3], collapse="."))
+		set(data, i, "filebase", paste0(curdir, "/", paste0(unlist(strsplit(basename(analysisFile), "\\."))[2:3], collapse=".")))
 	}
 }
 
 
+#Convert the data.table to a data.frame
+#TODO: Update the statements to use data.table style assignments and skip the conversion
+setDF(data)
 if(opt$project %in% c("humanENCODEdnase", "mouseENCODEdnase", "humanENCODEchipseq", "mouseENCODEchipseq")) {
 	#Fix sample age. 
 	#Only keep first entry e.g. male (week 7) male (week8)

--- a/dnase/trackhub/samplesforTrackhub.R
+++ b/dnase/trackhub/samplesforTrackhub.R
@@ -455,7 +455,6 @@ for(curdir in mappeddirs) {
 
 
 #Convert the data.table to a data.frame
-#TODO: Update the statements to use data.table style assignments and skip the conversion
 setDF(data)
 if(opt$project %in% c("humanENCODEdnase", "mouseENCODEdnase", "humanENCODEchipseq", "mouseENCODEchipseq")) {
 	#Fix sample age. 

--- a/dnase/trackhub/samplesforTrackhub.R
+++ b/dnase/trackhub/samplesforTrackhub.R
@@ -495,7 +495,7 @@ if(opt$project %in% c("humanENCODEdnase", "mouseENCODEdnase", "humanENCODEchipse
 
 if(opt$project=="CEGS_byLocus") {
 	# Delete line items not associated with one of the enumerated "CEGSsampleType" sample types.
-	data <- data[!is.na(data$Group),]
+	data <- data[!data$Group == "NA",]
 }
 
 #Output file:

--- a/dnase/trackhub/samplesforTrackhub.R
+++ b/dnase/trackhub/samplesforTrackhub.R
@@ -317,8 +317,7 @@ for(curdir in mappeddirs) {
 			#Note that color has already been established and won't be redone if sample name changes
 			
 			#Matching the DS number from the analysis file to inputSampleIDs can give multiple results, so just pick the first
-			# data.table[x, y] returns a list and needs to be indexed to extract the value
-			inputSampleIDrow <- which(inputSampleIDs[,"DS"] == data[i, "SampleID"][[1]])[1]
+			inputSampleIDrow <- which(inputSampleIDs[,"DS"] == data$SampleID[i])[1]
 			
 			#Take all columns to be taken from inputSampleIDs
 			for(curCol in intersect(outputCols, setdiff(colnames(inputSampleIDs), "DS"))) {


### PR DESCRIPTION
Fixes: #276

Profiling showed that the data `data.frame` was being duplicated after any updates.
Looking into this, I found that this is an issue when updating `data.frame` values.
Using `data.table` allows for values to be updated in place without the duplication cost.
But this required preallocating all the entries in the data table when it is created.

Another area I still need to investigate is improving the use of `grep` in the code.
There are two areas worth focusing on:
1. The same grep statement is being used in an if statement and then again in an assignment
  a. This could be improved by storing the result in a variable and using that instead
2. Some grep statements could be replaced with %in% statements, which might be faster

It will be worth looking into `data.table` `%like%` statements, which use grep.