### PR TITLE
fix: track description reproducibility

### DIFF
--- a/dnase/trackhub/MakeTrackhub.py
+++ b/dnase/trackhub/MakeTrackhub.py
@@ -169,7 +169,7 @@ if args.supertrack is not None:
 
 
 # Now build the composites, and add them all to the supertrack.
-for assay_type in assays:
+for assay_type in sorted(assays):
     #Matches the options allowed in submit.sh and createFlowcellSubmit.py
     bwaPipelineAnalysisCommandMap = { "DNase-seq": "dnase", "Nano-DNase": "dnase", "ATAC-seq":"atac", "ChIP-seq": "chipseq", "DNA": "dna", "DNA Capture": "capture", "Amplicon": "amplicon" }
     assay_suffix = bwaPipelineAnalysisCommandMap[assay_type] if assay_type in bwaPipelineAnalysisCommandMap else "none"

--- a/dnase/trackhub/makeChroms_per_cegsvectorHtml.R
+++ b/dnase/trackhub/makeChroms_per_cegsvectorHtml.R
@@ -12,7 +12,7 @@ desc_text <- read.table(fname_in, sep="|", header=FALSE, stringsAsFactors=FALSE)
 colnames(desc_text) <- c("Custom Reference", "Chromosomes")
 
 # Make the html version
-desc_HTML <- tableHTML(desc_text, rownames=FALSE, escape=FALSE) %>%
+desc_HTML <- tableHTML(desc_text, rownames=FALSE, escape=FALSE, class="description__table") %>%
 add_css_row(css = list('background-color', 'lightblue'), rows = odd(1:(1+nrow(desc_text)))) %>%
 add_css_row(css = list('background-color', 'white'), rows = even(1:(1+nrow(desc_text))))
 

--- a/dnase/trackhub/makeDescHtml.R
+++ b/dnase/trackhub/makeDescHtml.R
@@ -28,7 +28,7 @@ for (i in 1:ncol(desc_text)) {
 colnames(desc_text) <- chartr(old="_", new=" ", colnames(desc_text))
 
 # Make the html version
-desc_HTML <- tableHTML(desc_text, rownames=FALSE) %>%
+desc_HTML <- tableHTML(desc_text, rownames=FALSE, class='description__table') %>%
 add_css_row(css = list('background-color', 'lightblue'), rows = odd(1:(1+nrow(desc_text)))) %>%
 add_css_row(css = list('background-color', 'white'), rows = even(1:(1+nrow(desc_text))))
 


### PR DESCRIPTION
Changes:
+ Set a fixed class name instead of the default random name generated by the library
+ Sort the assays set to ensure the traversal order is the same between runs

Testing:
I ran the update_tracks.sh script twice and compared the output using `diff -q -r`. The only difference between the outputs is the `Hub was constructed at:` time. 

resolves #283 