### PR TITLE
fix allelic genotypes color by removing trackDb color setting for Genotypes tracks

### DIFF
--- a/dnase/trackhub/MakeTrackhub.py
+++ b/dnase/trackhub/MakeTrackhub.py
@@ -581,7 +581,6 @@ for assay_type in sorted(assays):
                         url=args.URLbase + urllib.parse.quote(curSample['filebase']) + '.genotypes.bb',
                         subgroups=sampleSubgroups,
                         tracktype='bigBed 9 .',
-                        color=curSample['Color'],
                         itemRgb="on",
                         parent="off"
                     )


### PR DESCRIPTION
Genotypes tracks have setting "color" as the color of current sample. Remove this setting so that color is drawn from column 9 of bigBed. 

I tested this by:

1. Copying the CEGS trackhub to my local public_html directory and loading this trackhub (https://LOGIN:PWD@mauranolab:chromatin@cascade.isg.med.nyu.edu/~ram851/trackhub_debug/hub.txt).
2. Changing the color of a test Genotypes track from 255,127,0 to 0,0,0. Only the Genotypes track changed to black.
3. Removing the setting color from a test Genotypes track. The Genotypes track changed to yellow/blue.